### PR TITLE
fix status request

### DIFF
--- a/Database/Bloodhound/Types.hs
+++ b/Database/Bloodhound/Types.hs
@@ -173,7 +173,7 @@ data Version = Version { number          :: Text
    <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-status.html#indices-status>
 -}
 
-data Status = Status { ok      :: Bool
+data Status = Status { ok      :: Maybe Bool
                      , status  :: Int
                      , name    :: Text
                      , version :: Version
@@ -1509,7 +1509,7 @@ instance FromJSON DocId
 
 instance FromJSON Status where
   parseJSON (Object v) = Status <$>
-                         v .: "ok" <*>
+                         v .:? "ok" <*>
                          v .: "status" <*>
                          v .: "name" <*>
                          v .: "version" <*>


### PR DESCRIPTION
As I can see in Elasticsearch v1.3.1 status "/" page does not return "ok" field.

Also it will be nice to use "eitherDecode" instead of "decode" in getStatus function.

``` haskell
getStatus :: Server -> IO (Maybe Status)
getStatus (Server server) = do
  request <- parseUrl $ joinPath [server]
  response <- withManager defaultManagerSettings $ httpLbs request
  return $ decode (responseBody response)
```

will be somehing like

``` haskell
getStatus :: Server -> IO (Either String Status)
getStatus (Server server) = do
  request <- parseUrl $ joinPath [server]
  response <- withManager defaultManagerSettings $ httpLbs request
  return $ eitherDecode (responseBody response)
```

at https://github.com/bitemyapp/bloodhound/blob/master/Database/Bloodhound/Client.hs#L92
