### PR TITLE
Adjusts the format of the OR filter

### DIFF
--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -1285,13 +1285,14 @@ instance Seminearring Filter where
 
 instance ToJSON Filter where
   toJSON (AndFilter filters cache) =
-    object ["and"     .=
+    object ["and" .=
             object [ "filters" .= fmap toJSON filters
-                   , "_cache" .= cache]]
+                   , "_cache"  .= cache]]
 
   toJSON (OrFilter filters cache) =
-    object ["or"      .= fmap toJSON filters
-           , "_cache" .= cache]
+    object ["or" .=
+            object [ "filters" .= fmap toJSON filters
+                   , "_cache"  .= cache]]
 
   toJSON (NotFilter notFilter cache) =
     object ["not" .=


### PR DESCRIPTION
Only verified on ES 1.2.1, but the fix is similiar to caecf0fe36ee12c26067081356269f45c11fe2fc.