### PR TITLE
Add Query Filter

### DIFF
--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -986,6 +986,7 @@ data Filter = AndFilter [Filter] Cache
             | LimitFilter Int
             | MissingFilter FieldName Existence NullValue
             | PrefixFilter  FieldName PrefixValue Cache
+            | QueryFilter   Query Cache
             | RangeFilter   FieldName RangeValue RangeExecution Cache
             | RegexpFilter  FieldName Regexp RegexpFlags CacheName Cache CacheKey
             | TermFilter    Term Cache
@@ -1427,6 +1428,13 @@ instance ToJSON Filter where
     object ["prefix" .=
             object [fieldName .= fieldValue
                    , "_cache" .= cache]]
+
+  toJSON (QueryFilter query False) =
+    object ["query" .= toJSON query ]
+  toJSON (QueryFilter query True) =
+    object ["fquery" .=
+            object [ "query"  .= toJSON query
+                   , "_cache" .= True ]]
 
   toJSON (RangeFilter (FieldName fieldName) rangeValue rangeExecution cache) =
     object ["range" .=

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -525,7 +525,6 @@ main = hspec $ do
       liftIO $
         myTweet `shouldBe` Right exampleTweet
 
-
     it "returns document for regexp filter" $ withTestEnv $ do
       _ <- insertData
       let filter = RegexpFilter (FieldName "user") (Regexp "bite.*app")
@@ -542,6 +541,20 @@ main = hspec $ do
                    (CacheName "test") False (CacheKey "key")
       let search = mkSearch Nothing (Just filter)
       searchExpectNoResults search
+
+    it "returns document for query filter, uncached" $ withTestEnv $ do
+      _ <- insertData
+      let filter = QueryFilter (TermQuery (Term "user" "bitemyapp") Nothing) True
+          search = mkSearch Nothing (Just filter)
+      myTweet <- searchTweet search
+      liftIO $ myTweet `shouldBe` Right exampleTweet
+
+    it "returns document for query filter, cached" $ withTestEnv $ do
+      _ <- insertData
+      let filter = QueryFilter (TermQuery (Term "user" "bitemyapp") Nothing) False
+          search = mkSearch Nothing (Just filter)
+      myTweet <- searchTweet search
+      liftIO $ myTweet `shouldBe` Right exampleTweet
 
   describe "Aggregation API" $ do
     it "returns term aggregation results" $ withTestEnv $ do


### PR DESCRIPTION
This adds the [Query Filter](https://www.elastic.co/guide/en/elasticsearch/reference/1.6/query-dsl-query-filter.html) filter. Tested ok on ElasticSearch 1.5.2, and it ought to work on all versions since 0.90.