### PR TITLE
Fixed bug with IndexSettings serialization

### DIFF
--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -91,7 +91,7 @@ import           Database.Bloodhound.Types
 -- >>> let runBH' = withBH defaultManagerSettings testServer
 -- >>> let testIndex = IndexName "twitter"
 -- >>> let testMapping = MappingName "tweet"
--- >>> let defaultIndexSettings = IndexSettings (ShardCount 3) (ReplicaCount 2)
+-- >>> let defaultIndexSettings = IndexSettings (ShardCount 1) (ReplicaCount 0)
 -- >>> data TweetMapping = TweetMapping deriving (Eq, Show)
 -- >>> _ <- runBH' $ deleteIndex testIndex >> deleteMapping testIndex testMapping
 -- >>> import GHC.Generics

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -2033,7 +2033,11 @@ instance FromJSON Status where
 
 
 instance ToJSON IndexSettings where
-  toJSON (IndexSettings s r) = object ["settings" .= object ["shards" .= s, "replicas" .= r]]
+  toJSON (IndexSettings s r) = object ["settings" .=
+                                 object ["index" .=
+                                   object ["number_of_shards" .= s, "number_of_replicas" .= r]
+                                 ]
+                               ]
 
 instance ToJSON IndexTemplate where
   toJSON (IndexTemplate p s m) = merge

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -47,7 +47,7 @@ validateStatus resp expected =
   `shouldBe` (expected :: Int)
 
 createExampleIndex :: BH IO Reply
-createExampleIndex = createIndex defaultIndexSettings testIndex
+createExampleIndex = createIndex (IndexSettings (ShardCount 1) (ReplicaCount 0)) testIndex
 deleteExampleIndex :: BH IO Reply
 deleteExampleIndex = deleteIndex testIndex
 


### PR DESCRIPTION
According to the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html), `IndexSettings` are serialized as `index.number_of_[shards|replicas]`, not merely `shards|replicas`.