### PR TITLE
export BH constructor

### DIFF
--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -47,7 +47,7 @@ module Database.Bloodhound.Types
        , toTerms
        , toDateHistogram
        , omitNulls
-       , BH
+       , BH(..)
        , runBH
        , BHEnv(..)
        , MonadBH(..)


### PR DESCRIPTION
Turns out if you have to implement instances (orphan or otherwise) for BH, it is pretty useful to export the full BH constructor. I can't really see any harm in exporting it other than if we at some point made a breaking change to the underlying value and were going to make it API-compatible by converting in runBH, but people would be using runBH anyways and would only be using the constructor for instance declarations/derivations.