### PR TITLE
Replace Control.Monad.Error with CM.Except via mtl-compat

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -39,7 +39,8 @@ library
                        exceptions,
                        data-default-class,
                        blaze-builder,
-                       unordered-containers
+                       unordered-containers,
+                       mtl-compat
   default-language:    Haskell2010
 
 test-suite tests

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -231,7 +231,7 @@ module Database.Bloodhound.Types
 
 import           Control.Applicative
 import           Control.Monad.Catch
-import           Control.Monad.Error
+import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Monad.State
 import           Control.Monad.Writer


### PR DESCRIPTION
Control.Monad.Error is deprecated since mtl-2.2.1.
mtl-compat is a module that backports the Control.Monad.Except module
providing backwards compatibility for users of mtl <= 2.2.0.