### PR TITLE
Add readme and changelog to extra source files

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -12,6 +12,11 @@ category:            Database, Search
 build-type:          Custom
 cabal-version:       >=1.10
 
+extra-source-files:
+  README.md
+  changelog.md
+
+
 source-repository head
   type:     git
   location: https://github.com/bitemyapp/bloodhound.git


### PR DESCRIPTION
Generally seems like good practice for the readme but there's a clear
benefit to adding changelog.md to extra-source-files: it gets parsed by
hackage and linked right from the haddocks!