### PR TITLE
Index aliases

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -45,7 +45,8 @@ library
                        data-default-class,
                        blaze-builder,
                        unordered-containers,
-                       mtl-compat
+                       mtl-compat,
+                       hashable
   default-language:    Haskell2010
 
 test-suite tests
@@ -68,7 +69,9 @@ test-suite tests
                        vector,
                        unordered-containers >= 0.2.5.0 && <0.3,
                        mtl,
-                       quickcheck-properties
+                       quickcheck-properties,
+                       derive,
+                       quickcheck-instances
   default-language:    Haskell2010
 
 test-suite doctests

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -287,7 +287,7 @@ parseEsResponse :: (MonadBH m, MonadThrow m, FromJSON a) => Reply
 parseEsResponse reply
   | respIsTwoHunna reply = case eitherDecode body of
                              Right a -> return (Right a)
-                             Left e -> case eitherDecode body of
+                             Left _ -> case eitherDecode body of
                                          Right e -> return (Left e)
                                          -- this case should not be possible
                                          Left _ -> explode
@@ -348,8 +348,9 @@ updateIndexAliases actions = bindM2 post url (return body)
         body = Just (encode bodyJSON)
         bodyJSON = object [ "actions" .= NE.toList actions]
 
-getIndexAliases :: (MonadBH m) => m (Either EsError IndexAliasesSummary)
-getIndexAliases = liftIO . parseEsResponse =<< get =<< url
+getIndexAliases :: (MonadBH m, MonadThrow m)
+                => m (Either EsError IndexAliasesSummary)
+getIndexAliases = parseEsResponse =<< get =<< url
   where url = joinPath ["_aliases"]
 
 -- | 'putTemplate' creates a template given an 'IndexTemplate' and a 'TemplateName'.

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -69,9 +69,10 @@ import           Control.Monad.IO.Class
 import           Data.Aeson
 import           Data.ByteString.Lazy.Builder
 import qualified Data.ByteString.Lazy.Char8   as L
+import           Data.Foldable                (toList)
 import           Data.Ix
 import qualified Data.List                    as LS (filter)
-import qualified Data.List.NonEmpty           as NE
+import           Data.List.NonEmpty           (NonEmpty (..))
 import           Data.Maybe                   (fromMaybe, isJust)
 import           Data.Monoid
 import           Data.Text                    (Text)
@@ -361,11 +362,11 @@ closeIndex = openOrCloseIndexes CloseIndex
 -- True
 -- >> respIsTwoHunna <$> runBH' (indexExists aliasName)
 -- True
-updateIndexAliases :: MonadBH m => NE.NonEmpty IndexAliasAction -> m Reply
+updateIndexAliases :: MonadBH m => NonEmpty IndexAliasAction -> m Reply
 updateIndexAliases actions = bindM2 post url (return body)
   where url = joinPath ["_aliases"]
         body = Just (encode bodyJSON)
-        bodyJSON = object [ "actions" .= NE.toList actions]
+        bodyJSON = object [ "actions" .= toList actions]
 
 -- | Get all aliases configured on the server.
 getIndexAliases :: (MonadBH m, MonadThrow m)

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -355,12 +355,17 @@ closeIndex = openOrCloseIndexes CloseIndex
 -- table. Operations are atomic. Explained in further detail at
 -- <https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html>
 --
--- >>> let aliasName = IndexName "twitter-alias"
--- >>> let iAlias = IndexAlias testIndex (IndexAliasName aliasName)
+-- >>> let src = IndexName "a-real-index"
+-- >>> let aliasName = IndexName "an-alias"
+-- >>> let iAlias = IndexAlias src (IndexAliasName aliasName)
 -- >>> let aliasCreate = IndexAliasCreate Nothing Nothing
+-- >>> respIsTwoHunna <$> runBH' (createIndex defaultIndexSettings src)
+-- True
+-- >>> runBH' $ indexExists src
+-- True
 -- >>> respIsTwoHunna <$> runBH' (updateIndexAliases (AddAlias iAlias aliasCreate :| []))
 -- True
--- >> respIsTwoHunna <$> runBH' (indexExists aliasName)
+-- >>> runBH' $ indexExists aliasName
 -- True
 updateIndexAliases :: MonadBH m => NonEmpty IndexAliasAction -> m Reply
 updateIndexAliases actions = bindM2 post url (return body)

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -283,6 +283,11 @@ existentialQuery url = do
   reply <- head url
   return (reply, respIsTwoHunna reply)
 
+
+-- | Tries to parse a response body as the expected type @a@ and
+-- failing that tries to parse it as an EsError. All well-formed, JSON
+-- responses from elasticsearch should fall into these two
+-- categories. If they don't, a 'StatusCodeException' will be thrown.
 parseEsResponse :: (MonadBH m, MonadThrow m, FromJSON a) => Reply
                 -> m (Either EsError a)
 parseEsResponse reply
@@ -362,6 +367,7 @@ updateIndexAliases actions = bindM2 post url (return body)
         body = Just (encode bodyJSON)
         bodyJSON = object [ "actions" .= NE.toList actions]
 
+-- | Get all aliases configured on the server.
 getIndexAliases :: (MonadBH m, MonadThrow m)
                 => m (Either EsError IndexAliasesSummary)
 getIndexAliases = parseEsResponse =<< get =<< url

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -344,6 +344,18 @@ openIndex = openOrCloseIndexes OpenIndex
 closeIndex :: MonadBH m => IndexName -> m Reply
 closeIndex = openOrCloseIndexes CloseIndex
 
+
+-- | 'updateIndexAliases' updates the server's index alias
+-- table. Operations are atomic. Explained in further detail at
+-- <https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html>
+--
+-- >>> let aliasName = IndexName "twitter-alias"
+-- >>> let iAlias = IndexAlias testIndex (IndexAliasName aliasName)
+-- >>> let aliasCreate = IndexAliasCreate Nothing Nothing
+-- >>> respIsTwoHunna <$> runBH' (updateIndexAliases (AddAlias iAlias aliasCreate :| []))
+-- True
+-- >> respIsTwoHunna <$> runBH' (indexExists aliasName)
+-- True
 updateIndexAliases :: MonadBH m => NE.NonEmpty IndexAliasAction -> m Reply
 updateIndexAliases actions = bindM2 post url (return body)
   where url = joinPath ["_aliases"]

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -469,6 +469,7 @@ newtype RoutingValue = RoutingValue { routingValue :: Text } deriving (Show, Eq,
 
 newtype IndexAliasesSummary = IndexAliasesSummary { indexAliasesSummary :: [IndexAliasSummary] } deriving (Show, Eq)
 
+{-| 'IndexAliasSummary' is a summary of an index alias configured for a server. -}
 data IndexAliasSummary = IndexAliasSummary { indexAliasSummaryAlias  :: IndexAlias
                                            , indexAliasSummaryCreate :: IndexAliasCreate} deriving (Show, Eq)
 

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -926,7 +926,7 @@ data SimpleQueryStringQuery =
     , simpleQueryStringFlags             :: Maybe (NonEmpty SimpleQueryFlag)
     , simpleQueryStringLowercaseExpanded :: Maybe LowercaseExpanded
     , simpleQueryStringLocale            :: Maybe Locale
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Typeable)
 
 data SimpleQueryFlag =
   SimpleQueryAll
@@ -1068,7 +1068,7 @@ data FuzzyLikeFieldQuery =
   , fuzzyLikeFieldPrefixLength        :: PrefixLength
   , fuzzyLikeFieldBoost               :: Boost
   , fuzzyLikeFieldAnalyzer            :: Maybe Analyzer
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Typeable)
 
 data FuzzyLikeThisQuery =
   FuzzyLikeThisQuery

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
@@ -262,6 +263,7 @@ import           Data.Text                       (Text)
 import qualified Data.Text                       as T
 import           Data.Time.Clock                 (UTCTime)
 import qualified Data.Traversable                as DT
+import           Data.Typeable                   (Typeable)
 import qualified Data.Vector                     as V
 import           GHC.Enum
 import           GHC.Generics                    (Generic)
@@ -335,7 +337,7 @@ data Version = Version { number          :: Text
                        , build_hash      :: Text
                        , build_timestamp :: UTCTime
                        , build_snapshot  :: Bool
-                       , lucene_version  :: Text } deriving (Eq, Show, Generic)
+                       , lucene_version  :: Text } deriving (Eq, Show, Generic, Typeable)
 
 {-| 'Status' is a data type for describing the JSON body returned by
     Elasticsearch when you query its status. This was deprecated in 1.2.0.
@@ -451,23 +453,23 @@ data IndexAlias = IndexAlias { srcIndex   :: IndexName
 newtype IndexAliasName = IndexAliasName { indexAliasName :: IndexName } deriving (Eq, Show, ToJSON)
 
 data IndexAliasAction = AddAlias IndexAlias IndexAliasCreate
-                      | RemoveAlias IndexAlias deriving (Show, Eq)
+                      | RemoveAlias IndexAlias deriving (Show, Eq, Typeable)
 
 data IndexAliasCreate = IndexAliasCreate { aliasCreateRouting :: Maybe AliasRouting
                                          , aliasCreateFilter  :: Maybe Filter}
-                                         deriving (Show, Eq)
+                                         deriving (Show, Eq, Typeable)
 
 data AliasRouting = AllAliasRouting RoutingValue
                   | GranularAliasRouting (Maybe SearchAliasRouting) (Maybe IndexAliasRouting)
-                  deriving (Show, Eq)
+                  deriving (Show, Eq, Typeable)
 
-newtype SearchAliasRouting = SearchAliasRouting (NonEmpty RoutingValue) deriving (Show, Eq)
+newtype SearchAliasRouting = SearchAliasRouting (NonEmpty RoutingValue) deriving (Show, Eq, Typeable)
 
-newtype IndexAliasRouting = IndexAliasRouting RoutingValue deriving (Show, Eq, ToJSON, FromJSON)
+newtype IndexAliasRouting = IndexAliasRouting RoutingValue deriving (Show, Eq, ToJSON, FromJSON, Typeable)
 
-newtype RoutingValue = RoutingValue { routingValue :: Text } deriving (Show, Eq, ToJSON, FromJSON)
+newtype RoutingValue = RoutingValue { routingValue :: Text } deriving (Show, Eq, ToJSON, FromJSON, Typeable)
 
-newtype IndexAliasesSummary = IndexAliasesSummary { indexAliasesSummary :: [IndexAliasSummary] } deriving (Show, Eq)
+newtype IndexAliasesSummary = IndexAliasesSummary { indexAliasesSummary :: [IndexAliasSummary] } deriving (Show, Eq, Typeable)
 
 {-| 'IndexAliasSummary' is a summary of an index alias configured for a server. -}
 data IndexAliasSummary = IndexAliasSummary { indexAliasSummaryAlias  :: IndexAlias
@@ -623,15 +625,15 @@ type PrefixValue = Text
 {-| 'BooleanOperator' is the usual And/Or operators with an ES compatible
     JSON encoding baked in. Used all over the place.
 -}
-data BooleanOperator = And | Or deriving (Eq, Show)
+data BooleanOperator = And | Or deriving (Eq, Show, Typeable)
 
 {-| 'ShardCount' is part of 'IndexSettings'
 -}
-newtype ShardCount = ShardCount Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype ShardCount = ShardCount Int deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'ReplicaCount' is part of 'IndexSettings'
 -}
-newtype ReplicaCount = ReplicaCount Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype ReplicaCount = ReplicaCount Int deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'Server' is used with the client functions to point at the ES instance
 -}
@@ -639,35 +641,35 @@ newtype Server = Server Text deriving (Eq, Show)
 
 {-| 'IndexName' is used to describe which index to query/create/delete
 -}
-newtype IndexName = IndexName Text deriving (Eq, Generic, Show, ToJSON, FromJSON)
+newtype IndexName = IndexName Text deriving (Eq, Generic, Show, ToJSON, FromJSON, Typeable)
 
 {-| 'TemplateName' is used to describe which template to query/create/delete
 -}
-newtype TemplateName = TemplateName Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype TemplateName = TemplateName Text deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'TemplatePattern' represents a pattern which is matched against index names
 -}
-newtype TemplatePattern = TemplatePattern Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype TemplatePattern = TemplatePattern Text deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'MappingName' is part of mappings which are how ES describes and schematizes
     the data in the indices.
 -}
-newtype MappingName = MappingName Text deriving (Eq, Generic, Show, ToJSON, FromJSON)
+newtype MappingName = MappingName Text deriving (Eq, Generic, Show, ToJSON, FromJSON, Typeable)
 
 {-| 'DocId' is a generic wrapper value for expressing unique Document IDs.
     Can be set by the user or created by ES itself. Often used in client
     functions for poking at specific documents.
 -}
-newtype DocId = DocId Text deriving (Eq, Generic, Show, ToJSON, FromJSON)
+newtype DocId = DocId Text deriving (Eq, Generic, Show, ToJSON, FromJSON, Typeable)
 
 {-| 'QueryString' is used to wrap query text bodies, be they human written or not.
 -}
-newtype QueryString = QueryString Text deriving (Eq, Generic, Show, ToJSON, FromJSON)
+newtype QueryString = QueryString Text deriving (Eq, Generic, Show, ToJSON, FromJSON, Typeable)
 
 {-| 'FieldName' is used all over the place wherever a specific field within
      a document needs to be specified, usually in 'Query's or 'Filter's.
 -}
-newtype FieldName = FieldName Text deriving (Eq, Show, ToJSON, FromJSON)
+newtype FieldName = FieldName Text deriving (Eq, Show, ToJSON, FromJSON, Typeable)
 
 
 {-| 'Script' is often used in place of 'FieldName' to specify more
@@ -678,98 +680,98 @@ newtype Script = Script { scriptText :: Text } deriving (Eq, Show)
 {-| 'CacheName' is used in 'RegexpFilter' for describing the
     'CacheKey' keyed caching behavior.
 -}
-newtype CacheName = CacheName Text deriving (Eq, Show, ToJSON, FromJSON)
+newtype CacheName = CacheName Text deriving (Eq, Show, ToJSON, FromJSON, Typeable)
 
 {-| 'CacheKey' is used in 'RegexpFilter' to key regex caching.
 -}
 newtype CacheKey =
-  CacheKey Text deriving (Eq, Show, ToJSON, FromJSON)
+  CacheKey Text deriving (Eq, Show, ToJSON, FromJSON, Typeable)
 newtype Existence =
-  Existence Bool deriving (Eq, Show, ToJSON, FromJSON)
+  Existence Bool deriving (Eq, Show, ToJSON, FromJSON, Typeable)
 newtype NullValue =
-  NullValue Bool deriving (Eq, Show, ToJSON, FromJSON)
+  NullValue Bool deriving (Eq, Show, ToJSON, FromJSON, Typeable)
 newtype CutoffFrequency =
-  CutoffFrequency Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  CutoffFrequency Double deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype Analyzer =
-  Analyzer Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  Analyzer Text deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype MaxExpansions =
-  MaxExpansions Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  MaxExpansions Int deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'Lenient', if set to true, will cause format based failures to be
     ignored. I don't know what the bloody default is, Elasticsearch
     documentation didn't say what it was. Let me know if you figure it out.
 -}
 newtype Lenient =
-  Lenient Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  Lenient Bool deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype Tiebreaker =
-  Tiebreaker Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  Tiebreaker Double deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype Boost =
-  Boost Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  Boost Double deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype BoostTerms =
-  BoostTerms Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  BoostTerms Double deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'MinimumMatch' controls how many should clauses in the bool query should
      match. Can be an absolute value (2) or a percentage (30%) or a
      combination of both.
 -}
 newtype MinimumMatch =
-  MinimumMatch Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  MinimumMatch Int deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype DisableCoord =
-  DisableCoord Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  DisableCoord Bool deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype IgnoreTermFrequency =
-  IgnoreTermFrequency Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  IgnoreTermFrequency Bool deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype MinimumTermFrequency =
-  MinimumTermFrequency Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  MinimumTermFrequency Int deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype MaxQueryTerms =
-  MaxQueryTerms Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  MaxQueryTerms Int deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype Fuzziness =
-  Fuzziness Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  Fuzziness Double deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'PrefixLength' is the prefix length used in queries, defaults to 0. -}
 newtype PrefixLength =
-  PrefixLength Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  PrefixLength Int deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype TypeName =
-  TypeName Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  TypeName Text deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype PercentMatch =
-  PercentMatch Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  PercentMatch Double deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype StopWord =
-  StopWord Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  StopWord Text deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype QueryPath =
-  QueryPath Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  QueryPath Text deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| Allowing a wildcard at the beginning of a word (eg "*ing") is particularly
     heavy, because all terms in the index need to be examined, just in case
     they match. Leading wildcards can be disabled by setting
     'AllowLeadingWildcard' to false. -}
 newtype AllowLeadingWildcard =
-  AllowLeadingWildcard     Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  AllowLeadingWildcard     Bool deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype LowercaseExpanded =
-  LowercaseExpanded        Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  LowercaseExpanded        Bool deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype EnablePositionIncrements =
-  EnablePositionIncrements Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  EnablePositionIncrements Bool deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| By default, wildcard terms in a query are not analyzed.
     Setting 'AnalyzeWildcard' to true enables best-effort analysis.
 -}
-newtype AnalyzeWildcard = AnalyzeWildcard Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype AnalyzeWildcard = AnalyzeWildcard Bool deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'GeneratePhraseQueries' defaults to false.
 -}
 newtype GeneratePhraseQueries =
-  GeneratePhraseQueries Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  GeneratePhraseQueries Bool deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'Locale' is used for string conversions - defaults to ROOT.
 -}
-newtype Locale        = Locale        Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
-newtype MaxWordLength = MaxWordLength Int  deriving (Eq, Show, Generic, ToJSON, FromJSON)
-newtype MinWordLength = MinWordLength Int  deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype Locale        = Locale        Text deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
+newtype MaxWordLength = MaxWordLength Int  deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
+newtype MinWordLength = MinWordLength Int  deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'PhraseSlop' sets the default slop for phrases, 0 means exact
      phrase matches. Default is 0.
 -}
-newtype PhraseSlop      = PhraseSlop      Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
-newtype MinDocFrequency = MinDocFrequency Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
-newtype MaxDocFrequency = MaxDocFrequency Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype PhraseSlop      = PhraseSlop      Int deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
+newtype MinDocFrequency = MinDocFrequency Int deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
+newtype MaxDocFrequency = MaxDocFrequency Int deriving (Eq, Show, Generic, ToJSON, FromJSON, Typeable)
 
 {-| 'unpackId' is a silly convenience function that gets used once.
 -}
@@ -898,19 +900,19 @@ data Query =
   | QuerySimpleQueryStringQuery SimpleQueryStringQuery
   | QueryRangeQuery             RangeQuery
   | QueryRegexpQuery            RegexpQuery
-  deriving (Eq, Show)
+  deriving (Eq, Show, Typeable)
 
 data RegexpQuery =
   RegexpQuery { regexpQueryField :: FieldName
               , regexpQuery      :: Regexp
               , regexpQueryFlags :: RegexpFlags
               , regexpQueryBoost :: Maybe Boost
-              } deriving (Eq, Show)
+              } deriving (Eq, Show, Typeable)
 
 data RangeQuery =
   RangeQuery { rangeQueryField :: FieldName
              , rangeQueryRange :: RangeValue
-             , rangeQueryBoost :: Boost } deriving (Eq, Show)
+             , rangeQueryBoost :: Boost } deriving (Eq, Show, Typeable)
 
 mkRangeQuery :: FieldName -> RangeValue -> RangeQuery
 mkRangeQuery f r = RangeQuery f r (Boost 1.0)
@@ -938,7 +940,7 @@ data SimpleQueryFlag =
   | SimpleQueryWhitespace
   | SimpleQueryFuzzy
   | SimpleQueryNear
-  | SimpleQuerySlop deriving (Eq, Show)
+  | SimpleQuerySlop deriving (Eq, Show, Typeable)
 
 -- use_dis_max and tie_breaker when fields are plural?
 data QueryStringQuery =
@@ -960,7 +962,7 @@ data QueryStringQuery =
   , queryStringMinimumShouldMatch       :: Maybe MinimumMatch
   , queryStringLenient                  :: Maybe Lenient
   , queryStringLocale                   :: Maybe Locale
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Typeable)
 
 mkQueryStringQuery :: QueryString -> QueryStringQuery
 mkQueryStringQuery qs =
@@ -971,19 +973,19 @@ mkQueryStringQuery qs =
   Nothing Nothing
 
 data FieldOrFields = FofField   FieldName
-                   | FofFields (NonEmpty FieldName) deriving (Eq, Show)
+                   | FofFields (NonEmpty FieldName) deriving (Eq, Show, Typeable)
 
 data PrefixQuery =
   PrefixQuery
   { prefixQueryField       :: FieldName
   , prefixQueryPrefixValue :: Text
-  , prefixQueryBoost       :: Maybe Boost } deriving (Eq, Show)
+  , prefixQueryBoost       :: Maybe Boost } deriving (Eq, Show, Typeable)
 
 data NestedQuery =
   NestedQuery
   { nestedQueryPath      :: QueryPath
   , nestedQueryScoreType :: ScoreType
-  , nestedQuery          :: Query } deriving (Eq, Show)
+  , nestedQuery          :: Query } deriving (Eq, Show, Typeable)
 
 data MoreLikeThisFieldQuery =
   MoreLikeThisFieldQuery
@@ -1001,7 +1003,7 @@ data MoreLikeThisFieldQuery =
   , moreLikeThisFieldBoostTerms      :: Maybe BoostTerms
   , moreLikeThisFieldBoost           :: Maybe Boost
   , moreLikeThisFieldAnalyzer        :: Maybe Analyzer
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Typeable)
 
 data MoreLikeThisQuery =
   MoreLikeThisQuery
@@ -1019,32 +1021,32 @@ data MoreLikeThisQuery =
   , moreLikeThisBoostTerms      :: Maybe BoostTerms
   , moreLikeThisBoost           :: Maybe Boost
   , moreLikeThisAnalyzer        :: Maybe Analyzer
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Typeable)
 
 data IndicesQuery =
   IndicesQuery
   { indicesQueryIndices :: [IndexName]
   , indicesQuery        :: Query
     -- default "all"
-  , indicesQueryNoMatch :: Maybe Query } deriving (Eq, Show)
+  , indicesQueryNoMatch :: Maybe Query } deriving (Eq, Show, Typeable)
 
 data HasParentQuery =
   HasParentQuery
   { hasParentQueryType      :: TypeName
   , hasParentQuery          :: Query
-  , hasParentQueryScoreType :: Maybe ScoreType } deriving (Eq, Show)
+  , hasParentQueryScoreType :: Maybe ScoreType } deriving (Eq, Show, Typeable)
 
 data HasChildQuery =
   HasChildQuery
   { hasChildQueryType      :: TypeName
   , hasChildQuery          :: Query
-  , hasChildQueryScoreType :: Maybe ScoreType } deriving (Eq, Show)
+  , hasChildQueryScoreType :: Maybe ScoreType } deriving (Eq, Show, Typeable)
 
 data ScoreType =
   ScoreTypeMax
   | ScoreTypeSum
   | ScoreTypeAvg
-  | ScoreTypeNone deriving (Eq, Show)
+  | ScoreTypeNone deriving (Eq, Show, Typeable)
 
 data FuzzyQuery =
   FuzzyQuery { fuzzyQueryField         :: FieldName
@@ -1053,7 +1055,7 @@ data FuzzyQuery =
              , fuzzyQueryMaxExpansions :: MaxExpansions
              , fuzzyQueryFuzziness     :: Fuzziness
              , fuzzyQueryBoost         :: Maybe Boost
-             } deriving (Eq, Show)
+             } deriving (Eq, Show, Typeable)
 
 data FuzzyLikeFieldQuery =
   FuzzyLikeFieldQuery
@@ -1078,19 +1080,19 @@ data FuzzyLikeThisQuery =
   , fuzzyLikePrefixLength        :: PrefixLength
   , fuzzyLikeBoost               :: Boost
   , fuzzyLikeAnalyzer            :: Maybe Analyzer
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Typeable)
 
 data FilteredQuery =
   FilteredQuery
   { filteredQuery  :: Query
-  , filteredFilter :: Filter } deriving (Eq, Show)
+  , filteredFilter :: Filter } deriving (Eq, Show, Typeable)
 
 data DisMaxQuery =
   DisMaxQuery { disMaxQueries    :: [Query]
                 -- default 0.0
               , disMaxTiebreaker :: Tiebreaker
               , disMaxBoost      :: Maybe Boost
-              } deriving (Eq, Show)
+              } deriving (Eq, Show, Typeable)
 
 data MatchQuery =
   MatchQuery { matchQueryField           :: FieldName
@@ -1102,7 +1104,7 @@ data MatchQuery =
              , matchQueryAnalyzer        :: Maybe Analyzer
              , matchQueryMaxExpansions   :: Maybe MaxExpansions
              , matchQueryLenient         :: Maybe Lenient
-             , matchQueryBoost           :: Maybe Boost } deriving (Eq, Show)
+             , matchQueryBoost           :: Maybe Boost } deriving (Eq, Show, Typeable)
 
 {-| 'mkMatchQuery' is a convenience function that defaults the less common parameters,
     enabling you to provide only the 'FieldName' and 'QueryString' to make a 'MatchQuery'
@@ -1112,7 +1114,7 @@ mkMatchQuery field query = MatchQuery field query Or ZeroTermsNone Nothing Nothi
 
 data MatchQueryType =
   MatchPhrase
-  | MatchPhrasePrefix deriving (Eq, Show)
+  | MatchPhrasePrefix deriving (Eq, Show, Typeable)
 
 data MultiMatchQuery =
   MultiMatchQuery { multiMatchQueryFields          :: [FieldName]
@@ -1124,7 +1126,7 @@ data MultiMatchQuery =
                   , multiMatchQueryCutoffFrequency :: Maybe CutoffFrequency
                   , multiMatchQueryAnalyzer        :: Maybe Analyzer
                   , multiMatchQueryMaxExpansions   :: Maybe MaxExpansions
-                  , multiMatchQueryLenient         :: Maybe Lenient } deriving (Eq, Show)
+                  , multiMatchQueryLenient         :: Maybe Lenient } deriving (Eq, Show, Typeable)
 
 {-| 'mkMultiMatchQuery' is a convenience function that defaults the less common parameters,
     enabling you to provide only the list of 'FieldName's and 'QueryString' to
@@ -1141,7 +1143,7 @@ data MultiMatchQueryType =
   | MultiMatchMostFields
   | MultiMatchCrossFields
   | MultiMatchPhrase
-  | MultiMatchPhrasePrefix deriving (Eq, Show)
+  | MultiMatchPhrasePrefix deriving (Eq, Show, Typeable)
 
 data BoolQuery =
   BoolQuery { boolQueryMustMatch          :: [Query]
@@ -1150,7 +1152,7 @@ data BoolQuery =
             , boolQueryMinimumShouldMatch :: Maybe MinimumMatch
             , boolQueryBoost              :: Maybe Boost
             , boolQueryDisableCoord       :: Maybe DisableCoord
-            } deriving (Eq, Show)
+            } deriving (Eq, Show, Typeable)
 
 mkBoolQuery :: [Query] -> [Query] -> [Query] -> BoolQuery
 mkBoolQuery must mustNot should =
@@ -1159,7 +1161,7 @@ mkBoolQuery must mustNot should =
 data BoostingQuery =
   BoostingQuery { positiveQuery :: Query
                 , negativeQuery :: Query
-                , negativeBoost :: Boost } deriving (Eq, Show)
+                , negativeBoost :: Boost } deriving (Eq, Show, Typeable)
 
 data CommonTermsQuery =
   CommonTermsQuery { commonField              :: FieldName
@@ -1171,16 +1173,16 @@ data CommonTermsQuery =
                    , commonBoost              :: Maybe Boost
                    , commonAnalyzer           :: Maybe Analyzer
                    , commonDisableCoord       :: Maybe DisableCoord
-                   } deriving (Eq, Show)
+                   } deriving (Eq, Show, Typeable)
 
 data CommonMinimumMatch =
     CommonMinimumMatchHighLow MinimumMatchHighLow
   | CommonMinimumMatch        MinimumMatch
-  deriving (Eq, Show)
+  deriving (Eq, Show, Typeable)
 
 data MinimumMatchHighLow =
   MinimumMatchHighLow { lowFreq  :: MinimumMatch
-                      , highFreq :: MinimumMatch } deriving (Eq, Show)
+                      , highFreq :: MinimumMatch } deriving (Eq, Show, Typeable)
 
 data Filter = AndFilter [Filter] Cache
             | OrFilter  [Filter] Cache
@@ -1200,13 +1202,13 @@ data Filter = AndFilter [Filter] Cache
             | RangeFilter   FieldName RangeValue RangeExecution Cache
             | RegexpFilter  FieldName Regexp RegexpFlags CacheName Cache CacheKey
             | TermFilter    Term Cache
-              deriving (Eq, Show)
+              deriving (Eq, Show, Typeable)
 
 data ZeroTermsQuery = ZeroTermsNone
-                    | ZeroTermsAll deriving (Eq, Show)
+                    | ZeroTermsAll deriving (Eq, Show, Typeable)
 
 data RangeExecution = RangeExecutionIndex
-                    | RangeExecutionFielddata deriving (Eq, Show)
+                    | RangeExecutionFielddata deriving (Eq, Show, Typeable)
 
 newtype Regexp = Regexp Text deriving (Eq, Show, FromJSON)
 
@@ -1269,33 +1271,33 @@ rangeValueToPair rv = case rv of
   RangeDoubleGtLt (GreaterThan l) (LessThan g)       -> ["gt"  .= l, "lt"  .= g]
 
 data Term = Term { termField :: Text
-                 , termValue :: Text } deriving (Eq, Show)
+                 , termValue :: Text } deriving (Eq, Show, Typeable)
 
 data BoolMatch = MustMatch    Term  Cache
                | MustNotMatch Term  Cache
-               | ShouldMatch [Term] Cache deriving (Eq, Show)
+               | ShouldMatch [Term] Cache deriving (Eq, Show, Typeable)
 
 -- "memory" or "indexed"
 data GeoFilterType = GeoFilterMemory
-                   | GeoFilterIndexed deriving (Eq, Show)
+                   | GeoFilterIndexed deriving (Eq, Show, Typeable)
 
 data LatLon = LatLon { lat :: Double
-                     , lon :: Double } deriving (Eq, Show)
+                     , lon :: Double } deriving (Eq, Show, Typeable)
 
 data GeoBoundingBox =
   GeoBoundingBox { topLeft     :: LatLon
-                 , bottomRight :: LatLon } deriving (Eq, Show)
+                 , bottomRight :: LatLon } deriving (Eq, Show, Typeable)
 
 data GeoBoundingBoxConstraint =
   GeoBoundingBoxConstraint { geoBBField        :: FieldName
                            , constraintBox     :: GeoBoundingBox
                            , bbConstraintcache :: Cache
                            , geoType           :: GeoFilterType
-                           } deriving (Eq, Show)
+                           } deriving (Eq, Show, Typeable)
 
 data GeoPoint =
   GeoPoint { geoField :: FieldName
-           , latLon   :: LatLon} deriving (Eq, Show)
+           , latLon   :: LatLon} deriving (Eq, Show, Typeable)
 
 data DistanceUnit = Miles
                   | Yards
@@ -1305,18 +1307,18 @@ data DistanceUnit = Miles
                   | Meters
                   | Centimeters
                   | Millimeters
-                  | NauticalMiles deriving (Eq, Show)
+                  | NauticalMiles deriving (Eq, Show, Typeable)
 
 data DistanceType = Arc
                   | SloppyArc -- doesn't exist <1.0
-                  | Plane deriving (Eq, Show)
+                  | Plane deriving (Eq, Show, Typeable)
 
 data OptimizeBbox = OptimizeGeoFilterType GeoFilterType
-                  | NoOptimizeBbox deriving (Eq, Show)
+                  | NoOptimizeBbox deriving (Eq, Show, Typeable)
 
 data Distance =
   Distance { coefficient :: Double
-           , unit        :: DistanceUnit } deriving (Eq, Show)
+           , unit        :: DistanceUnit } deriving (Eq, Show, Typeable)
 
 data DistanceRange =
   DistanceRange { distanceFrom :: Distance

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -468,10 +468,10 @@ newtype IndexAliasRouting = IndexAliasRouting RoutingValue deriving (Show, Eq, T
 
 newtype RoutingValue = RoutingValue { routingValue :: Text } deriving (Show, Eq, ToJSON, FromJSON)
 
-newtype IndexAliasesSummary = IndexAliasesSummary [IndexAliasSummary]
+newtype IndexAliasesSummary = IndexAliasesSummary { indexAliasesSummary :: [IndexAliasSummary] } deriving (Show, Eq)
 
 data IndexAliasSummary = IndexAliasSummary { indexAliasSummaryAlias  :: IndexAlias
-                                           , indexAliasSummaryCreate :: IndexAliasCreate}
+                                           , indexAliasSummaryCreate :: IndexAliasCreate} deriving (Show, Eq)
 
 {-| 'DocVersion' is an integer version number for a document between 1
 and 9.2e+18 used for <<https://www.elastic.co/guide/en/elasticsearch/guide/current/optimistic-concurrency-control.html optimistic concurrency control>>.

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -624,11 +624,11 @@ data BooleanOperator = And | Or deriving (Eq, Show)
 
 {-| 'ShardCount' is part of 'IndexSettings'
 -}
-newtype ShardCount = ShardCount Int deriving (Eq, Show, Generic)
+newtype ShardCount = ShardCount Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'ReplicaCount' is part of 'IndexSettings'
 -}
-newtype ReplicaCount = ReplicaCount Int deriving (Eq, Show, Generic)
+newtype ReplicaCount = ReplicaCount Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'Server' is used with the client functions to point at the ES instance
 -}
@@ -636,35 +636,35 @@ newtype Server = Server Text deriving (Eq, Show)
 
 {-| 'IndexName' is used to describe which index to query/create/delete
 -}
-newtype IndexName = IndexName Text deriving (Eq, Generic, Show)
+newtype IndexName = IndexName Text deriving (Eq, Generic, Show, ToJSON, FromJSON)
 
 {-| 'TemplateName' is used to describe which template to query/create/delete
 -}
-newtype TemplateName = TemplateName Text deriving (Eq, Show, Generic)
+newtype TemplateName = TemplateName Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'TemplatePattern' represents a pattern which is matched against index names
 -}
-newtype TemplatePattern = TemplatePattern Text deriving (Eq, Show, Generic)
+newtype TemplatePattern = TemplatePattern Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'MappingName' is part of mappings which are how ES describes and schematizes
     the data in the indices.
 -}
-newtype MappingName = MappingName Text deriving (Eq, Generic, Show)
+newtype MappingName = MappingName Text deriving (Eq, Generic, Show, ToJSON, FromJSON)
 
 {-| 'DocId' is a generic wrapper value for expressing unique Document IDs.
     Can be set by the user or created by ES itself. Often used in client
     functions for poking at specific documents.
 -}
-newtype DocId = DocId Text deriving (Eq, Generic, Show)
+newtype DocId = DocId Text deriving (Eq, Generic, Show, ToJSON, FromJSON)
 
 {-| 'QueryString' is used to wrap query text bodies, be they human written or not.
 -}
-newtype QueryString = QueryString Text deriving (Eq, Generic, Show)
+newtype QueryString = QueryString Text deriving (Eq, Generic, Show, ToJSON, FromJSON)
 
 {-| 'FieldName' is used all over the place wherever a specific field within
      a document needs to be specified, usually in 'Query's or 'Filter's.
 -}
-newtype FieldName = FieldName Text deriving (Eq, Show, FromJSON)
+newtype FieldName = FieldName Text deriving (Eq, Show, ToJSON, FromJSON)
 
 
 {-| 'Script' is often used in place of 'FieldName' to specify more
@@ -675,100 +675,100 @@ newtype Script = Script { scriptText :: Text } deriving (Eq, Show)
 {-| 'CacheName' is used in 'RegexpFilter' for describing the
     'CacheKey' keyed caching behavior.
 -}
-newtype CacheName = CacheName Text deriving (Eq, Show, FromJSON)
+newtype CacheName = CacheName Text deriving (Eq, Show, ToJSON, FromJSON)
 
 {-| 'CacheKey' is used in 'RegexpFilter' to key regex caching.
 -}
 newtype CacheKey =
-  CacheKey Text deriving (Eq, Show, FromJSON)
+  CacheKey Text deriving (Eq, Show, ToJSON, FromJSON)
 newtype Existence =
-  Existence Bool deriving (Eq, Show, FromJSON)
+  Existence Bool deriving (Eq, Show, ToJSON, FromJSON)
 newtype NullValue =
-  NullValue Bool deriving (Eq, Show, FromJSON)
+  NullValue Bool deriving (Eq, Show, ToJSON, FromJSON)
 newtype CutoffFrequency =
-  CutoffFrequency Double deriving (Eq, Show, Generic)
+  CutoffFrequency Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype Analyzer =
-  Analyzer Text deriving (Eq, Show, Generic)
+  Analyzer Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype MaxExpansions =
-  MaxExpansions Int deriving (Eq, Show, Generic)
+  MaxExpansions Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'Lenient', if set to true, will cause format based failures to be
     ignored. I don't know what the bloody default is, Elasticsearch
     documentation didn't say what it was. Let me know if you figure it out.
 -}
 newtype Lenient =
-  Lenient Bool deriving (Eq, Show, Generic)
+  Lenient Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype Tiebreaker =
-  Tiebreaker Double deriving (Eq, Show, Generic)
+  Tiebreaker Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype Boost =
-  Boost Double deriving (Eq, Show, Generic)
+  Boost Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype BoostTerms =
-  BoostTerms Double deriving (Eq, Show, Generic)
+  BoostTerms Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'MinimumMatch' controls how many should clauses in the bool query should
      match. Can be an absolute value (2) or a percentage (30%) or a
      combination of both.
 -}
 newtype MinimumMatch =
-  MinimumMatch Int deriving (Eq, Show, Generic)
+  MinimumMatch Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype MinimumMatchText =
-  MinimumMatchText Text deriving (Eq, Show)
+  MinimumMatchText Text deriving (Eq, Show, ToJSON, FromJSON)
 newtype DisableCoord =
-  DisableCoord Bool deriving (Eq, Show, Generic)
+  DisableCoord Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype IgnoreTermFrequency =
-  IgnoreTermFrequency Bool deriving (Eq, Show, Generic)
+  IgnoreTermFrequency Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype MinimumTermFrequency =
-  MinimumTermFrequency Int deriving (Eq, Show, Generic)
+  MinimumTermFrequency Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype MaxQueryTerms =
-  MaxQueryTerms Int deriving (Eq, Show, Generic)
+  MaxQueryTerms Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype Fuzziness =
-  Fuzziness Double deriving (Eq, Show, Generic)
+  Fuzziness Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'PrefixLength' is the prefix length used in queries, defaults to 0. -}
 newtype PrefixLength =
-  PrefixLength Int deriving (Eq, Show, Generic)
+  PrefixLength Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype TypeName =
-  TypeName Text deriving (Eq, Show, Generic)
+  TypeName Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype PercentMatch =
-  PercentMatch Double deriving (Eq, Show, Generic)
+  PercentMatch Double deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype StopWord =
-  StopWord Text deriving (Eq, Show, Generic)
+  StopWord Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype QueryPath =
-  QueryPath Text deriving (Eq, Show, Generic)
+  QueryPath Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| Allowing a wildcard at the beginning of a word (eg "*ing") is particularly
     heavy, because all terms in the index need to be examined, just in case
     they match. Leading wildcards can be disabled by setting
     'AllowLeadingWildcard' to false. -}
 newtype AllowLeadingWildcard =
-  AllowLeadingWildcard     Bool deriving (Eq, Show, Generic)
+  AllowLeadingWildcard     Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype LowercaseExpanded =
-  LowercaseExpanded        Bool deriving (Eq, Show, Generic)
+  LowercaseExpanded        Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
 newtype EnablePositionIncrements =
-  EnablePositionIncrements Bool deriving (Eq, Show, Generic)
+  EnablePositionIncrements Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| By default, wildcard terms in a query are not analyzed.
     Setting 'AnalyzeWildcard' to true enables best-effort analysis.
 -}
-newtype AnalyzeWildcard = AnalyzeWildcard Bool deriving (Eq, Show, Generic)
+newtype AnalyzeWildcard = AnalyzeWildcard Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'GeneratePhraseQueries' defaults to false.
 -}
 newtype GeneratePhraseQueries =
-  GeneratePhraseQueries Bool deriving (Eq, Show, Generic)
+  GeneratePhraseQueries Bool deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'Locale' is used for string conversions - defaults to ROOT.
 -}
-newtype Locale        = Locale        Text deriving (Eq, Show, Generic)
-newtype MaxWordLength = MaxWordLength Int  deriving (Eq, Show, Generic)
-newtype MinWordLength = MinWordLength Int  deriving (Eq, Show, Generic)
+newtype Locale        = Locale        Text deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype MaxWordLength = MaxWordLength Int  deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype MinWordLength = MinWordLength Int  deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'PhraseSlop' sets the default slop for phrases, 0 means exact
      phrase matches. Default is 0.
 -}
-newtype PhraseSlop      = PhraseSlop      Int deriving (Eq, Show, Generic)
-newtype MinDocFrequency = MinDocFrequency Int deriving (Eq, Show, Generic)
-newtype MaxDocFrequency = MaxDocFrequency Int deriving (Eq, Show, Generic)
+newtype PhraseSlop      = PhraseSlop      Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype MinDocFrequency = MinDocFrequency Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
+newtype MaxDocFrequency = MaxDocFrequency Int deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 {-| 'unpackId' is a silly convenience function that gets used once.
 -}
@@ -1448,6 +1448,22 @@ mkTermsScriptAggregation t = TermsAggregation (Right t) Nothing Nothing Nothing 
 mkDateHistogram :: FieldName -> Interval -> DateHistogramAggregation
 mkDateHistogram t i = DateHistogramAggregation t i Nothing Nothing Nothing Nothing Nothing Nothing
 
+instance ToJSON Version where
+  toJSON Version {..} = object ["number" .= number
+                               ,"build_hash" .= build_hash
+                               ,"build_timestamp" .= build_timestamp
+                               ,"build_snapshot" .= build_snapshot
+                               ,"lucene_version" .= lucene_version]
+
+instance FromJSON Version where
+  parseJSON = withObject "Version" parse
+    where parse o = Version
+                    <$> o .: "number"
+                    <*> o .: "build_hash"
+                    <*> o .: "build_timestamp"
+                    <*> o .: "build_snapshot"
+                    <*> o .: "lucene_version"
+
 instance ToJSON TermOrder where
   toJSON (TermOrder termSortField termSortOrder) = object [termSortField .= termSortOrder]
 
@@ -1729,13 +1745,13 @@ instance FromJSON Filter where
           missingFilter o = MissingFilter <$> o .: "field"
                                           <*> o .: "existence"
                                           <*> o .: "null_value"
-          prefixFilter o = fieldTagged $ \fn o' -> PrefixFilter fn <$> parseJSON (Object o')
-                                                                   <*> o .:? "_cache" .!= defaultCache
+          prefixFilter o = flip fieldTagged o $ \fn o' -> PrefixFilter fn <$> parseJSON (Object o')
+                                                                          <*> o .:? "_cache" .!= defaultCache
           queryFilter q = pure (QueryFilter q False)
           fqueryFilter o = QueryFilter <$> o .: "query" <*> pure True
-          rangeFilter o = fieldTagged $ \fn o' -> RangeFilter fn <$> parseJSON (Object o')
-                                                                 <*> o .: "execution"
-                                                                 <*> o .:? "_cache" .!= defaultCache
+          rangeFilter o = flip fieldTagged o $ \fn o' -> RangeFilter fn <$> parseJSON (Object o')
+                                                                        <*> o .: "execution"
+                                                                        <*> o .:? "_cache" .!= defaultCache
           regexpFilter = fieldTagged $ \fn o -> RegexpFilter fn <$> o .: "value"
                                                                 <*> o .: "flags"
                                                                 <*> o .: "_name"
@@ -1744,10 +1760,11 @@ instance FromJSON Filter where
           termFilter o = flip fieldTagged o $ \(FieldName fn) o' -> do
             trm <- Term fn <$> parseJSON (Object o')
             TermFilter trm <$> o .: "_cache" .!= defaultCache
-          --TODO: should this enforce there only being 1 key?
-          fieldTagged f o = case HM.toList o of
-                              [(k, Object o')] -> f (FieldName k) o'
-                              _ -> fail "Expected object with 1 field named key"
+
+fieldTagged :: Monad m => (FieldName -> Object -> m a) -> Object -> m a
+fieldTagged f o = case HM.toList o of
+                    [(k, Object o')] -> f (FieldName k) o'
+                    _ -> fail "Expected object with 1 field-named key"
 
 instance ToJSON GeoPoint where
   toJSON (GeoPoint (FieldName geoPointField) geoPointLatLon) =
@@ -1848,6 +1865,73 @@ instance ToJSON Query where
   toJSON (QuerySimpleQueryStringQuery query) =
     object [ "simple_query_string" .= query ]
 
+instance FromJSON Query where
+  parseJSON = withObject "Query" parse
+    where parse o = termQuery `taggedWith` "term"
+                <|> termsQuery `taggedWith` "terms"
+                <|> idsQuery `taggedWith` "ids"
+                <|> queryQueryStringQuery `taggedWith` "query_string"
+                <|> queryMatchQuery `taggedWith` "match"
+                <|> queryMultiMatchQuery o --TODO: is this a precedence issue?
+                <|> queryBoolQuery `taggedWith` "bool"
+                <|> queryBoostingQuery `taggedWith` "boosting"
+                <|> queryCommonTermsQuery `taggedWith` "common"
+                <|> constantScoreFilter o
+                <|> constantScoreQuery o
+                <|> queryDisMaxQuery `taggedWith` "dis_max"
+                <|> queryFilteredQuery `taggedWith` "filtered"
+                <|> queryFuzzyLikeThisQuery `taggedWith` "fuzzy_like_this"
+                <|> queryFuzzyLikeFieldQuery `taggedWith` "fuzzy_like_this_field"
+                <|> queryFuzzyQuery `taggedWith` "fuzzy"
+                <|> queryHasChildQuery `taggedWith` "has_child"
+                <|> queryHasParentQuery `taggedWith` "has_parent"
+                <|> queryIndicesQuery `taggedWith` "indices"
+                <|> matchAllQuery `taggedWith` "match_all"
+                <|> queryMoreLikeThisQuery `taggedWith` "more_like_this"
+                <|> queryMoreLikeThisFieldQuery `taggedWith` "more_like_this_field"
+                <|> queryNestedQuery `taggedWith` "nested"
+                <|> queryPrefixQuery `taggedWith` "prefix"
+                <|> queryRangeQuery `taggedWith` "range"
+                <|> queryRegexpQuery `taggedWith` "regexp"
+                <|> querySimpleQueryStringQuery `taggedWith` "simple_query_string"
+            where taggedWith parser k = parser =<< o .: k
+          termQuery o = TermQuery <$> parseJSON (Object o)
+                                  <*> o .:? "boost"
+          termsQuery o = case HM.toList o of
+                           [(fn, vs)] -> do vals <- parseJSON vs
+                                            case vals of
+                                              x:xs -> return (TermsQuery (Term fn <$> x :| xs))
+                                              _ -> fail "Expected non empty list of values"
+                           _ -> fail "Expected object with 1 field-named key"
+          idsQuery o = IdsQuery <$> o .: "type"
+                                <*> o .: "values"
+          queryQueryStringQuery = pure . QueryQueryStringQuery
+          queryMatchQuery = pure . QueryMatchQuery
+          queryMultiMatchQuery = undefined
+          queryBoolQuery = pure . QueryBoolQuery
+          queryBoostingQuery = pure . QueryBoostingQuery
+          queryCommonTermsQuery = pure . QueryCommonTermsQuery
+          constantScoreFilter o = ConstantScoreFilter <$> o .: "constant_score"
+                                                      <*> o .: "boost"
+          constantScoreQuery o = ConstantScoreQuery <$> o .: "constant_score"
+                                                    <*> o .: "boost"
+          queryDisMaxQuery = pure . QueryDisMaxQuery
+          queryFilteredQuery = pure . QueryFilteredQuery
+          queryFuzzyLikeThisQuery = pure . QueryFuzzyLikeThisQuery
+          queryFuzzyLikeFieldQuery = pure . QueryFuzzyLikeFieldQuery
+          queryFuzzyQuery = pure . QueryFuzzyQuery
+          queryHasChildQuery = pure . QueryHasChildQuery
+          queryHasParentQuery = pure . QueryHasParentQuery
+          queryIndicesQuery = pure . QueryIndicesQuery
+          matchAllQuery o = MatchAllQuery <$> o .:? "boost"
+          queryMoreLikeThisQuery = pure . QueryMoreLikeThisQuery
+          queryMoreLikeThisFieldQuery = pure . QueryMoreLikeThisFieldQuery
+          queryNestedQuery = pure . QueryNestedQuery
+          queryPrefixQuery = pure . QueryPrefixQuery
+          queryRangeQuery = pure . QueryRangeQuery
+          queryRegexpQuery = pure . QueryRegexpQuery
+          querySimpleQueryStringQuery = pure . QuerySimpleQueryStringQuery
+
 
 omitNulls :: [(Text, Value)] -> Value
 omitNulls = object . filter notNull where
@@ -1867,12 +1951,25 @@ instance ToJSON SimpleQueryStringQuery where
                      , "lowercase_expanded_terms" .= simpleQueryStringLowercaseExpanded
                      , "locale" .= simpleQueryStringLocale ]
 
+instance FromJSON SimpleQueryStringQuery where
+  parseJSON = withObject "SimpleQueryStringQuery" parse
+    where parse o = SimpleQueryStringQuery <$> o .: "query"
+                                           <*> o .:? "fields"
+                                           <*> o .:? "default_operator"
+                                           <*> o .:? "analyzer"
+                                           <*> o .:? "flags"
+                                           <*> o .:? "lowercase_expanded_terms"
+                                           <*> o .:? "locale"
 
 instance ToJSON FieldOrFields where
   toJSON (FofField fieldName) =
     toJSON fieldName
   toJSON (FofFields fieldNames) =
     toJSON fieldNames
+
+instance FromJSON FieldOrFields where
+  parseJSON v = FofField  <$> parseJSON v
+            <|> FofFields <$> parseJSON v
 
 instance ToJSON SimpleQueryFlag where
   toJSON SimpleQueryAll        = "ALL"
@@ -1888,6 +1985,21 @@ instance ToJSON SimpleQueryFlag where
   toJSON SimpleQueryNear       = "NEAR"
   toJSON SimpleQuerySlop       = "SLOP"
 
+instance FromJSON SimpleQueryFlag where
+  parseJSON = withText "SimpleQueryFlag" parse
+    where parse "ALL"        = pure SimpleQueryAll
+          parse "NONE"       = pure SimpleQueryNone
+          parse "AND"        = pure SimpleQueryAnd
+          parse "OR"         = pure SimpleQueryOr
+          parse "PREFIX"     = pure SimpleQueryPrefix
+          parse "PHRASE"     = pure SimpleQueryPhrase
+          parse "PRECEDENCE" = pure SimpleQueryPrecedence
+          parse "ESCAPE"     = pure SimpleQueryEscape
+          parse "WHITESPACE" = pure SimpleQueryWhitespace
+          parse "FUZZY"      = pure SimpleQueryFuzzy
+          parse "NEAR"       = pure SimpleQueryNear
+          parse "SLOP"       = pure SimpleQuerySlop
+          parse f            = fail ("Unexpected SimpleQueryFlag: " <> show f)
 
 instance ToJSON RegexpQuery where
   toJSON (RegexpQuery (FieldName rqQueryField)
@@ -1898,6 +2010,13 @@ instance ToJSON RegexpQuery where
                 , "flags" .= rqQueryFlags
                 , "boost" .= rqQueryBoost ]
 
+instance FromJSON RegexpQuery where
+  parseJSON = withObject "RegexpQuery" parse
+    where parse = fieldTagged $ \fn o ->
+                    RegexpQuery fn
+                    <$> o .: "value"
+                    <*> o .: "flags"
+                    <*> o .:? "boost"
 
 instance ToJSON QueryStringQuery where
   toJSON (QueryStringQuery qsQueryString
@@ -1929,15 +2048,71 @@ instance ToJSON QueryStringQuery where
              , "lenient" .= qsLenient
              , "locale" .= qsLocale ]
 
+instance FromJSON QueryStringQuery where
+  parseJSON = withObject "QueryStringQuery" parse
+    where parse o = QueryStringQuery
+                    <$> o .: "query"
+                    <*> o .:? "default_field"
+                    <*> o .:? "default_operator"
+                    <*> o .:? "analyzer"
+                    <*> o .:? "allow_leading_wildcard"
+                    <*> o .:? "lowercase_expanded_terms"
+                    <*> o .:? "enable_position_increments"
+                    <*> o .:? "fuzzy_max_expansions"
+                    <*> o .:? "fuzziness"
+                    <*> o .:? "fuzzy_prefix_length"
+                    <*> o .:? "phrase_slop"
+                    <*> o .:? "boost"
+                    <*> o .:? "analyze_wildcard"
+                    <*> o .:? "auto_generate_phrase_queries"
+                    <*> o .:? "minimum_should_match"
+                    <*> o .:? "lenient"
+                    <*> o .:? "locale"
 
 instance ToJSON RangeQuery where
   toJSON (RangeQuery (FieldName fieldName) range boost) =
     object [ fieldName .= conjoined ]
     where conjoined = [ "boost" .= boost ] ++ (rangeValueToPair range)
 
+instance FromJSON RangeQuery where
+  parseJSON = withObject "RangeQuery" parse
+    where parse = fieldTagged $ \fn o ->
+                    RangeQuery fn
+                    <$> parseJSON (Object o)
+                    <*> o .: "boost"
+
 instance FromJSON RangeValue where
   parseJSON = withObject "RangeValue" parse
-    where parse o = undefined
+    where parse o = parseDate o
+                <|> parseDouble o
+          parseDate o = do lt <- o .:? "lt"
+                           lte <- o .:? "lte"
+                           gt <- o .:? "gt"
+                           gte <- o .:? "gte"
+                           case (lt, lte, gt, gte) of
+                             (Just a, _, Just b, _) -> return (RangeDateGtLt (GreaterThanD a) (LessThanD b))
+                             (Just a, _, _, Just b)-> return (RangeDateGteLt (GreaterThanEqD a) (LessThanD b))
+                             (_, Just a, Just b, _)-> return (RangeDateGtLte (GreaterThanD a) (LessThanEqD b))
+                             (_, Just a, _, Just b)-> return (RangeDateGteLte (GreaterThanEqD a) (LessThanEqD b))
+                             (_, _, Just a, _)-> return (RangeDateGt (GreaterThanD a))
+                             (Just a, _, _, _)-> return (RangeDateLt (LessThanD a))
+                             (_, _, _, Just a)-> return (RangeDateGte (GreaterThanEqD a))
+                             (_, Just a, _, _)-> return (RangeDateLte (LessThanEqD a))
+                             (Nothing, Nothing, Nothing, Nothing) -> mzero
+          parseDouble o = do lt <- o .:? "lt"
+                             lte <- o .:? "lte"
+                             gt <- o .:? "gt"
+                             gte <- o .:? "gte"
+                             case (lt, lte, gt, gte) of
+                               (Just a, _, Just b, _) -> return (RangeDoubleGtLt (GreaterThan a) (LessThan b))
+                               (Just a, _, _, Just b)-> return (RangeDoubleGteLt (GreaterThanEq a) (LessThan b))
+                               (_, Just a, Just b, _)-> return (RangeDoubleGtLte (GreaterThan a) (LessThanEq b))
+                               (_, Just a, _, Just b)-> return (RangeDoubleGteLte (GreaterThanEq a) (LessThanEq b))
+                               (_, _, Just a, _)-> return (RangeDoubleGt (GreaterThan a))
+                               (Just a, _, _, _)-> return (RangeDoubleLt (LessThan a))
+                               (_, _, _, Just a)-> return (RangeDoubleGte (GreaterThanEq a))
+                               (_, Just a, _, _)-> return (RangeDoubleLte (LessThanEq a))
+                               (Nothing, Nothing, Nothing, Nothing) -> mzero
 
 instance ToJSON PrefixQuery where
   toJSON (PrefixQuery (FieldName fieldName) queryValue boost) =
@@ -1945,6 +2120,12 @@ instance ToJSON PrefixQuery where
     where base = [ "value" .= queryValue
                  , "boost" .= boost ]
 
+instance FromJSON PrefixQuery where
+  parseJSON = withObject "PrefixQuery" parse
+    where parse = fieldTagged $ \fn o ->
+                    PrefixQuery fn
+                    <$> o .: "value"
+                    <*> o .:? "boost"
 
 instance ToJSON NestedQuery where
   toJSON (NestedQuery nqPath nqScoreType nqQuery) =
@@ -1952,6 +2133,12 @@ instance ToJSON NestedQuery where
            , "score_mode" .= nqScoreType
            , "query"      .= nqQuery ]
 
+instance FromJSON NestedQuery where
+  parseJSON = withObject "NestedQuery" parse
+    where parse o = NestedQuery
+                    <$> o .: "path"
+                    <*> o .: "score_mode"
+                    <*> o .: "query"
 
 instance ToJSON MoreLikeThisFieldQuery where
   toJSON (MoreLikeThisFieldQuery text (FieldName fieldName)
@@ -1971,6 +2158,23 @@ instance ToJSON MoreLikeThisFieldQuery where
                  , "boost" .= boost
                  , "analyzer" .= analyzer ]
 
+instance FromJSON MoreLikeThisFieldQuery where
+  parseJSON = withObject "MoreLikeThisFieldQuery" parse
+    where parse = fieldTagged $ \fn o ->
+                    MoreLikeThisFieldQuery
+                    <$> o .: "like_text"
+                    <*> pure fn
+                    <*> o .:? "percent_terms_to_match"
+                    <*> o .:? "min_term_freq"
+                    <*> o .:? "max_query_terms"
+                    <*> o .:? "stop_words"
+                    <*> o .:? "min_doc_freq"
+                    <*> o .:? "max_doc_freq"
+                    <*> o .:? "min_word_length"
+                    <*> o .:? "max_word_length"
+                    <*> o .:? "boost_terms"
+                    <*> o .:? "boost"
+                    <*> o .:? "analyzer"
 
 instance ToJSON MoreLikeThisQuery where
   toJSON (MoreLikeThisQuery text fields percent
@@ -1991,6 +2195,22 @@ instance ToJSON MoreLikeThisQuery where
                  , "boost" .= boost
                  , "analyzer" .= analyzer ]
 
+instance FromJSON MoreLikeThisQuery where
+  parseJSON = withObject "MoreLikeThisQuery" parse
+    where parse o = MoreLikeThisQuery
+                    <$> o .: "like_text"
+                    <*> o .:? "fields"
+                    <*> o .:? "percent_terms_to_match"
+                    <*> o .:? "min_term_freq"
+                    <*> o .:? "max_query_terms"
+                    <*> o .:? "stop_words"
+                    <*> o .:? "min_doc_freq"
+                    <*> o .:? "max_doc_freq"
+                    <*> o .:? "min_word_length"
+                    <*> o .:? "max_word_length"
+                    <*> o .:? "boost_terms"
+                    <*> o .:? "boost"
+                    <*> o .:? "analyzer"
 
 instance ToJSON IndicesQuery where
   toJSON (IndicesQuery indices query noMatch) =
@@ -1998,6 +2218,12 @@ instance ToJSON IndicesQuery where
               , "no_match_query" .= noMatch
               , "query" .= query ]
 
+instance FromJSON IndicesQuery where
+  parseJSON = withObject "IndicesQuery" parse
+    where parse o = IndicesQuery
+                    <$> o .: "indices"
+                    <*> o .: "query"
+                    <*> o .:? "no_match_query"
 
 instance ToJSON HasParentQuery where
   toJSON (HasParentQuery queryType query scoreType) =
@@ -2005,6 +2231,12 @@ instance ToJSON HasParentQuery where
               , "score_type" .= scoreType
               , "query" .= query ]
 
+instance FromJSON HasParentQuery where
+  parseJSON = withObject "HasParentQuery" parse
+    where parse o = HasParentQuery
+                    <$> o .: "parent_type"
+                    <*> o .: "query"
+                    <*> o .:? "score_type"
 
 instance ToJSON HasChildQuery where
   toJSON (HasChildQuery queryType query scoreType) =
@@ -2012,6 +2244,12 @@ instance ToJSON HasChildQuery where
               , "score_type" .= scoreType
               , "type"  .= queryType ]
 
+instance FromJSON HasChildQuery where
+  parseJSON = withObject "HasChildQuery" parse
+    where parse o = HasChildQuery
+                    <$> o .: "type"
+                    <*> o .: "query"
+                    <*> o .:? "score_type"
 
 instance ToJSON FuzzyQuery where
   toJSON (FuzzyQuery (FieldName fieldName) queryText
@@ -2023,6 +2261,15 @@ instance ToJSON FuzzyQuery where
                  , "boost" .= boost
                  , "max_expansions" .= maxEx ]
 
+instance FromJSON FuzzyQuery where
+  parseJSON = withObject "FuzzyQuery" parse
+    where parse = fieldTagged $ \fn o ->
+                    FuzzyQuery fn
+                    <$> o .: "value"
+                    <*> o .: "prefix_length"
+                    <*> o .: "max_expansions"
+                    <*> o .: "fuzziness"
+                    <*> o .:? "boost"
 
 instance ToJSON FuzzyLikeFieldQuery where
   toJSON (FuzzyLikeFieldQuery (FieldName fieldName)
@@ -2037,6 +2284,17 @@ instance ToJSON FuzzyLikeFieldQuery where
                        , "analyzer" .= analyzer
                        , "boost"           .= boost ]]
 
+instance FromJSON FuzzyLikeFieldQuery where
+  parseJSON = withObject "FuzzyLikeFieldQuery" parse
+    where parse = fieldTagged $ \fn o ->
+                    FuzzyLikeFieldQuery fn
+                    <$> o .: "like_text"
+                    <*> o .: "max_query_terms"
+                    <*> o .: "ignore_tf"
+                    <*> o .: "fuzziness"
+                    <*> o .: "prefix_length"
+                    <*> o .: "boost"
+                    <*> o .:? "analyzer"
 
 instance ToJSON FuzzyLikeThisQuery where
   toJSON (FuzzyLikeThisQuery fields text maxTerms
@@ -2051,12 +2309,28 @@ instance ToJSON FuzzyLikeThisQuery where
                  , "analyzer"        .= analyzer
                  , "boost"           .= boost ]
 
+instance FromJSON FuzzyLikeThisQuery where
+  parseJSON = withObject "FuzzyLikeThisQuery" parse
+    where parse o = FuzzyLikeThisQuery
+                    <$> o .: "fields"
+                    <*> o .: "like_text"
+                    <*> o .: "max_query_terms"
+                    <*> o .: "ignore_tf"
+                    <*> o .: "fuzziness"
+                    <*> o .: "prefix_length"
+                    <*> o .: "boost"
+                    <*> o .:? "analyzer"
 
 instance ToJSON FilteredQuery where
   toJSON (FilteredQuery query fFilter) =
     object [ "query"  .= query
            , "filter" .= fFilter ]
 
+instance FromJSON FilteredQuery where
+  parseJSON = withObject "FilteredQuery" parse
+    where parse o = FilteredQuery
+                    <$> o .: "query"
+                    <*> o .: "filter"
 
 instance ToJSON DisMaxQuery where
   toJSON (DisMaxQuery queries tiebreaker boost) =
@@ -2065,6 +2339,12 @@ instance ToJSON DisMaxQuery where
                  , "boost"       .= boost
                  , "tie_breaker" .= tiebreaker ]
 
+instance FromJSON DisMaxQuery where
+  parseJSON = withObject "DisMaxQuery" parse
+    where parse o = DisMaxQuery
+                    <$> o .: "queries"
+                    <*> o .: "tie_breaker"
+                    <*> o .:? "boost"
 
 instance ToJSON CommonTermsQuery where
   toJSON (CommonTermsQuery (FieldName fieldName)
@@ -2080,6 +2360,18 @@ instance ToJSON CommonTermsQuery where
                  , "disable_coord" .= disableCoord
                  , "high_freq_operator" .= hfo ]
 
+instance FromJSON CommonTermsQuery where
+  parseJSON = withObject "CommonTermsQuery" parse
+    where parse = fieldTagged $ \fn o ->
+                    CommonTermsQuery fn
+                    <$> o .: "query"
+                    <*> o .: "cutoff_frequency"
+                    <*> o .: "low_freq_operator"
+                    <*> o .: "high_freq_operator"
+                    <*> o .:? "minimum_should_match"
+                    <*> o .:? "boost"
+                    <*> o .:? "analyzer"
+                    <*> o .:? "disable_coord"
 
 instance ToJSON CommonMinimumMatch where
   toJSON (CommonMinimumMatch mm) = toJSON mm
@@ -2087,12 +2379,28 @@ instance ToJSON CommonMinimumMatch where
     object [ "low_freq"  .= lowF
            , "high_freq" .= highF ]
 
+instance FromJSON CommonMinimumMatch where
+  parseJSON v = parseMinimum v
+            <|> parseMinimumHighLow v
+    where parseMinimum = fmap CommonMinimumMatch . parseJSON
+          parseMinimumHighLow = fmap CommonMinimumMatchHighLow . withObject "CommonMinimumMatchHighLow" (\o ->
+                                  MinimumMatchHighLow
+                                  <$> o .: "low_freq"
+                                  <*> o .: "high_freq")
+
+
 instance ToJSON BoostingQuery where
   toJSON (BoostingQuery bqPositiveQuery bqNegativeQuery bqNegativeBoost) =
     object [ "positive"       .= bqPositiveQuery
            , "negative"       .= bqNegativeQuery
            , "negative_boost" .= bqNegativeBoost ]
 
+instance FromJSON BoostingQuery where
+  parseJSON = withObject "BoostingQuery" parse
+    where parse o = BoostingQuery
+                    <$> o .: "positive"
+                    <*> o .: "negative"
+                    <*> o .: "negative_boost"
 
 instance ToJSON BoolQuery where
   toJSON (BoolQuery mustM notM shouldM bqMin boost disableCoord) =
@@ -2104,6 +2412,15 @@ instance ToJSON BoolQuery where
                  , "boost" .= boost
                  , "disable_coord" .= disableCoord ]
 
+instance FromJSON BoolQuery where
+  parseJSON = withObject "BoolQuery" parse
+    where parse o = BoolQuery
+                    <$> o .:? "must" .!= []
+                    <*> o .:? "must_not" .!= []
+                    <*> o .:? "should" .!= []
+                    <*> o .:? "minimum_should_match"
+                    <*> o .:? "boost"
+                    <*> o .:? "disable_coord"
 
 instance ToJSON MatchQuery where
   toJSON (MatchQuery (FieldName fieldName)
@@ -2121,6 +2438,19 @@ instance ToJSON MatchQuery where
                  , "lenient" .= lenient
                  , "boost" .= boost ]
 
+instance FromJSON MatchQuery where
+  parseJSON = withObject "MatchQuery" parse
+    where parse = fieldTagged $ \fn o ->
+                    MatchQuery fn
+                    <$> o .:  "query"
+                    <*> o .:  "operator"
+                    <*> o .:  "zero_terms_query"
+                    <*> o .:? "cutoff_frequency"
+                    <*> o .:? "type"
+                    <*> o .:? "analyzer"
+                    <*> o .:? "max_expansions"
+                    <*> o .:? "lenient"
+                    <*> o .:? "boost"
 
 instance ToJSON MultiMatchQuery where
   toJSON (MultiMatchQuery fields (QueryString query) boolOp
@@ -2145,106 +2475,44 @@ instance ToJSON MultiMatchQueryType where
   toJSON MultiMatchPhrase = "phrase"
   toJSON MultiMatchPhrasePrefix = "phrase_prefix"
 
+instance FromJSON MultiMatchQueryType where
+  parseJSON = withText "MultiMatchPhrasePrefix" parse
+    where parse "best_fields"   = pure MultiMatchBestFields
+          parse "most_fields"   = pure MultiMatchMostFields
+          parse "cross_fields"  = pure MultiMatchCrossFields
+          parse "phrase"        = pure MultiMatchPhrase
+          parse "phrase_prefix" = pure MultiMatchPhrasePrefix
+          parse t = fail ("Unexpected MultiMatchPhrasePrefix: " <> show t)
+
 instance ToJSON BooleanOperator where
   toJSON And = String "and"
   toJSON Or = String "or"
+
+instance FromJSON BooleanOperator where
+  parseJSON = withText "BooleanOperator" parse
+    where parse "and" = pure And
+          parse "or"  = pure Or
+          parse o     = fail ("Unexpected BooleanOperator: " <> show o)
 
 instance ToJSON ZeroTermsQuery where
   toJSON ZeroTermsNone = String "none"
   toJSON ZeroTermsAll  = String "all"
 
+instance FromJSON ZeroTermsQuery where
+  parseJSON = withText "ZeroTermsQuery" parse
+    where parse "none" = pure ZeroTermsNone
+          parse "all"  = pure ZeroTermsAll
+          parse q      = fail ("Unexpected ZeroTermsQuery: " <> show q)
+
 instance ToJSON MatchQueryType where
   toJSON MatchPhrase = "phrase"
   toJSON MatchPhrasePrefix = "phrase_prefix"
 
-instance ToJSON FieldName where
-  toJSON (FieldName fieldName) = String fieldName
-
-instance ToJSON ReplicaCount where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON ShardCount where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON CutoffFrequency where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON Analyzer where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON MaxExpansions where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON Lenient where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON Boost where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON Version where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON Tiebreaker where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON MinimumMatch where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON DisableCoord where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON PrefixLength where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON Fuzziness where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON IgnoreTermFrequency where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON MaxQueryTerms where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON TypeName where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON IndexName where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON TemplateName where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON TemplatePattern where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON BoostTerms where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON MaxWordLength where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON MinWordLength where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON MaxDocFrequency where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON MinDocFrequency where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON PhraseSlop where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON StopWord where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON QueryPath where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON MinimumTermFrequency where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON PercentMatch where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON MappingName where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON DocId where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON QueryString where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON AllowLeadingWildcard where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON LowercaseExpanded where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON AnalyzeWildcard where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON GeneratePhraseQueries where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON Locale where
-  toJSON = genericToJSON defaultOptions
-instance ToJSON EnablePositionIncrements where
-  toJSON = genericToJSON defaultOptions
-
-instance FromJSON Version where
-  parseJSON = genericParseJSON defaultOptions
-instance FromJSON IndexName where
-  parseJSON = genericParseJSON defaultOptions
-instance FromJSON MappingName where
-  parseJSON = genericParseJSON defaultOptions
-instance FromJSON DocId where
-  parseJSON = genericParseJSON defaultOptions
+instance FromJSON MatchQueryType where
+  parseJSON = withText "MatchQueryType" parse
+    where parse "phrase"        = pure MatchPhrase
+          parse "phrase_prefix" = pure MatchPhrasePrefix
+          parse t               = fail ("Unexpected MatchQueryType: " <> show t)
 
 instance FromJSON Status where
   parseJSON (Object v) = Status <$>
@@ -2508,6 +2776,13 @@ instance ToJSON ScoreType where
   toJSON ScoreTypeSum  = "sum"
   toJSON ScoreTypeNone = "none"
 
+instance FromJSON ScoreType where
+  parseJSON = withText "ScoreType" parse
+    where parse "max" = pure ScoreTypeMax
+          parse "avg" = pure ScoreTypeAvg
+          parse "sum" = pure ScoreTypeSum
+          parse "non" = pure ScoreTypeNone
+          parse t = fail ("Unexpected ScoreType: " <> show t)
 
 instance ToJSON Distance where
   toJSON (Distance dCoefficient dUnit) =
@@ -2580,6 +2855,13 @@ instance ToJSON GeoBoundingBoxConstraint where
            , "_cache"  .= cache
            , "type" .= type']
 
+instance FromJSON GeoBoundingBoxConstraint where
+  parseJSON = withObject "GeoBoundingBoxConstraint" parse
+    where parse o = flip fieldTagged o $ \fn o' -> 
+                      GeoBoundingBoxConstraint fn
+                      <$> parseJSON (Object o')
+                      <*> o .:? "cache" .!= defaultCache
+                      <*> o .: "type"
 
 instance ToJSON GeoFilterType where
   toJSON GeoFilterMemory  = String "memory"
@@ -2596,6 +2878,11 @@ instance ToJSON GeoBoundingBox where
     object ["top_left"      .= gbbTopLeft
            , "bottom_right" .= gbbBottomRight]
 
+instance FromJSON GeoBoundingBox where
+  parseJSON = withObject "GeoBoundingBox" parse
+    where parse o = GeoBoundingBox
+                    <$> o .: "top_left"
+                    <*> o .: "bottom_right"
 
 instance ToJSON LatLon where
   toJSON (LatLon lLat lLon) =
@@ -2640,7 +2927,6 @@ instance FromJSON RegexpFlags where
 instance FromJSON RegexpFlag where
   parseJSON = withText "RegexpFlag" parse
     where parse "ANYSTRING"    = pure AnyString
-          parse "ANYSTRING"    = pure AnyString
           parse "AUTOMATON"    = pure Automaton
           parse "COMPLEMENT"   = pure Complement
           parse "EMPTY"        = pure Empty
@@ -2652,6 +2938,12 @@ instance ToJSON Term where
   toJSON (Term field value) = object ["term" .= object
                                       [field .= value]]
 
+instance FromJSON Term where
+  parseJSON = withObject "Term" parse
+    where parse o = do termObj <- o .: "term"
+                       case HM.toList termObj of
+                         [(fn, v)] -> Term fn <$> parseJSON v
+                         _ -> fail "Expected object with 1 field-named key"
 
 instance ToJSON BoolMatch where
   toJSON (MustMatch    term  cache) = object ["must"     .= term,
@@ -2661,6 +2953,15 @@ instance ToJSON BoolMatch where
   toJSON (ShouldMatch  terms cache) = object ["should"   .= fmap toJSON terms,
                                               "_cache" .= cache]
 
+instance FromJSON BoolMatch where
+  parseJSON = withObject "BoolMatch" parse
+    where parse o = mustMatch `taggedWith` "must"
+                <|> mustNotMatch `taggedWith` "must_not"
+                <|> shouldMatch `taggedWith` "should"
+            where taggedWith parser k = parser =<< o .: k
+                  mustMatch t = MustMatch t <$> o .:? "_cache" .!= defaultCache
+                  mustNotMatch t = MustNotMatch t <$> o .:? "_cache" .!= defaultCache
+                  shouldMatch t = ShouldMatch t <$> o .:? "_cache" .!= defaultCache
 
 instance (FromJSON a) => FromJSON (SearchResult a) where
   parseJSON (Object v) = SearchResult <$>

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -351,6 +351,56 @@ instance Arbitrary RegexpFlags where
 instance Arbitrary IndexAliasCreate where
   arbitrary = IndexAliasCreate <$> arbitrary <*> reduceSize arbitrary
 
+instance Arbitrary Query where
+  arbitrary = reduceSize $ oneof [ TermQuery <$> arbitrary <*> arbitrary
+                                 , TermsQuery <$> arbitrary <*> arbitrary
+                                 , QueryMatchQuery <$> arbitrary
+                                 , QueryMultiMatchQuery <$> arbitrary
+                                 , QueryBoolQuery <$> arbitrary
+                                 , QueryBoostingQuery <$> arbitrary
+                                 , QueryCommonTermsQuery <$> arbitrary
+                                 , ConstantScoreFilter <$> arbitrary <*> arbitrary
+                                 , ConstantScoreQuery <$> arbitrary <*> arbitrary
+                                 , QueryDisMaxQuery <$> arbitrary
+                                 , QueryFilteredQuery <$> arbitrary
+                                 , QueryFuzzyLikeThisQuery <$> arbitrary
+                                 , QueryFuzzyLikeFieldQuery <$> arbitrary
+                                 , QueryFuzzyQuery <$> arbitrary
+                                 , QueryHasChildQuery <$> arbitrary
+                                 , QueryHasParentQuery <$> arbitrary
+                                 , IdsQuery <$> arbitrary <*> arbitrary
+                                 , QueryIndicesQuery <$> arbitrary
+                                 , MatchAllQuery <$> arbitrary
+                                 , QueryMoreLikeThisQuery <$> arbitrary
+                                 , QueryMoreLikeThisFieldQuery <$> arbitrary
+                                 , QueryNestedQuery <$> arbitrary
+                                 , QueryPrefixQuery <$> arbitrary
+                                 , QueryQueryStringQuery <$> arbitrary
+                                 , QuerySimpleQueryStringQuery <$> arbitrary
+                                 , QueryRangeQuery <$> arbitrary
+                                 , QueryRegexpQuery <$> arbitrary
+                                 ]
+
+instance Arbitrary Filter where
+  arbitrary = reduceSize $ oneof [ AndFilter <$> arbitrary <*> arbitrary
+                                 , OrFilter <$> arbitrary <*> arbitrary
+                                 , NotFilter <$> arbitrary <*> arbitrary
+                                 , pure IdentityFilter
+                                 , BoolFilter <$> arbitrary
+                                 , ExistsFilter <$> arbitrary
+                                 , GeoBoundingBoxFilter <$> arbitrary
+                                 , GeoDistanceFilter <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+                                 , GeoDistanceRangeFilter <$> arbitrary <*> arbitrary
+                                 , GeoPolygonFilter <$> arbitrary <*> arbitrary
+                                 , IdsFilter <$> arbitrary <*> arbitrary
+                                 , LimitFilter <$> arbitrary
+                                 , MissingFilter <$> arbitrary <*> arbitrary <*> arbitrary
+                                 , PrefixFilter <$> arbitrary <*> arbitrary <*> arbitrary
+                                 , QueryFilter <$> arbitrary <*> arbitrary
+                                 , RangeFilter <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+                                 , RegexpFilter <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+                                 , TermFilter <$> arbitrary <*> arbitrary]
+
 $(derive makeArbitrary ''IndexName)
 $(derive makeArbitrary ''MappingName)
 $(derive makeArbitrary ''DocId)
@@ -394,8 +444,6 @@ $(derive makeArbitrary ''PhraseSlop)
 $(derive makeArbitrary ''MinDocFrequency)
 $(derive makeArbitrary ''MaxDocFrequency)
 $(derive makeArbitrary ''Regexp)
-$(derive makeArbitrary ''Filter)
-$(derive makeArbitrary ''Query)
 $(derive makeArbitrary ''SimpleQueryStringQuery)
 $(derive makeArbitrary ''FieldOrFields)
 $(derive makeArbitrary ''SimpleQueryFlag)

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Main where
 
@@ -9,21 +10,25 @@ import           Control.Exception
 import           Control.Monad
 import           Control.Monad.Reader
 import           Data.Aeson
+import           Data.Aeson.Types                (parseEither)
+import           Data.DeriveTH
 import qualified Data.HashMap.Strict             as HM
 import           Data.List                       (nub)
 import           Data.List.NonEmpty              (NonEmpty (..))
 import qualified Data.List.NonEmpty              as NE
 import qualified Data.Map.Strict                 as M
 import           Data.Monoid
+import           Data.Proxy
 import           Data.Text                       (Text)
 import qualified Data.Text                       as T
 import           Data.Time.Calendar              (Day (..))
 import           Data.Time.Clock                 (UTCTime (..),
                                                   secondsToDiffTime)
+import           Data.Typeable
 import qualified Data.Vector                     as V
 import           Database.Bloodhound
 import           GHC.Generics                    (Generic)
-import           Network.HTTP.Client
+import           Network.HTTP.Client             hiding (Proxy)
 import qualified Network.HTTP.Types.Status       as NHTS
 import           Prelude                         hiding (filter)
 import           Test.Hspec
@@ -31,6 +36,7 @@ import           Test.QuickCheck.Property.Monoid (T (..), eq, prop_Monoid)
 
 import           Test.Hspec.QuickCheck           (prop)
 import           Test.QuickCheck
+import           Test.QuickCheck.Instances       ()
 
 testServer  :: Server
 testServer  = Server "http://localhost:9200"
@@ -100,6 +106,12 @@ is v = testServerBranch >>= \x -> return $ x == Just (serverBranch v)
 
 when' :: Monad m => m Bool -> m () -> m ()
 when' b f = b >>= \x -> when x f
+
+propJSON :: forall a. (Arbitrary a, ToJSON a, FromJSON a, Show a, Eq a, Typeable a) => Proxy a -> Spec
+propJSON _ = prop testName $ \(a :: a) ->
+  parseEither parseJSON (toJSON a) === Right a
+  where testName = show ty <> " FromJSON/ToJSON roundtrips"
+        ty = typeOf (undefined :: a)
 
 data Location = Location { lat :: Double
                          , lon :: Double } deriving (Eq, Generic, Show)
@@ -265,41 +277,11 @@ instance ToJSON BulkTest where
 noDuplicates :: Eq a => [a] -> Bool
 noDuplicates xs = nub xs == xs
 
-instance Arbitrary RegexpFlags where
-  arbitrary = oneof [ pure AllRegexpFlags
-                    , pure NoRegexpFlags
-                    , SomeRegexpFlags <$> arbitrary
-                    ]
-
 instance Arbitrary a => Arbitrary (NonEmpty a) where
   arbitrary = liftA2 (:|) arbitrary arbitrary
 
-instance Arbitrary RegexpFlag where
-  arbitrary = oneof [ pure AnyString
-                    , pure Automaton
-                    , pure Complement
-                    , pure Empty
-                    , pure Intersection
-                    , pure Interval
-                    ]
-
 arbitraryScore :: Gen Score
 arbitraryScore = fmap getPositive <$> arbitrary
-
-instance Arbitrary Text where
-  arbitrary = T.pack <$> arbitrary
-
-instance (Arbitrary k, Arbitrary v, Ord k) => Arbitrary (M.Map k v) where
-  arbitrary = M.fromList <$> arbitrary
-
-instance Arbitrary IndexName where
-  arbitrary = IndexName <$> arbitrary
-
-instance Arbitrary MappingName where
-  arbitrary = MappingName <$> arbitrary
-
-instance Arbitrary DocId where
-  arbitrary = DocId <$> arbitrary
 
 instance Arbitrary a => Arbitrary (Hit a) where
   arbitrary = Hit <$> arbitrary
@@ -326,6 +308,135 @@ grabFirst r =
     (Left e) -> Left e
     (Right Nothing) -> Left "Source was missing"
     (Right (Just x)) -> Right x
+
+-------------------------------------------------------------------------------
+arbitraryAlphaNum :: Gen Char
+arbitraryAlphaNum = oneof [choose ('a', 'z')
+                          ,choose ('A','Z')
+                          , choose ('0', '9')]
+
+instance Arbitrary RoutingValue where
+  arbitrary = RoutingValue . T.pack <$> listOf1 arbitraryAlphaNum
+
+instance Arbitrary AliasRouting where
+  arbitrary = oneof [allAlias
+                    ,one
+                    ,theOther
+                    ,both]
+    where one = GranularAliasRouting
+                <$> (Just <$> arbitrary)
+                <*> pure Nothing
+          theOther = GranularAliasRouting Nothing
+                     <$> (Just <$> arbitrary)
+          both = GranularAliasRouting
+                 <$> (Just <$> arbitrary)
+                 <*> (Just <$> arbitrary)
+          allAlias = AllAliasRouting <$> arbitrary
+
+$(derive makeArbitrary ''IndexName)
+$(derive makeArbitrary ''FieldName)
+$(derive makeArbitrary ''MappingName)
+$(derive makeArbitrary ''DocId)
+$(derive makeArbitrary ''Version)
+$(derive makeArbitrary ''IndexAliasRouting)
+$(derive makeArbitrary ''ShardCount)
+$(derive makeArbitrary ''ReplicaCount)
+$(derive makeArbitrary ''TemplateName)
+$(derive makeArbitrary ''TemplatePattern)
+$(derive makeArbitrary ''QueryString)
+$(derive makeArbitrary ''CacheName)
+$(derive makeArbitrary ''CacheKey)
+$(derive makeArbitrary ''Existence)
+$(derive makeArbitrary ''CutoffFrequency)
+$(derive makeArbitrary ''Analyzer)
+$(derive makeArbitrary ''MaxExpansions)
+$(derive makeArbitrary ''Lenient)
+$(derive makeArbitrary ''Tiebreaker)
+$(derive makeArbitrary ''Boost)
+$(derive makeArbitrary ''BoostTerms)
+$(derive makeArbitrary ''MinimumMatch)
+$(derive makeArbitrary ''DisableCoord)
+$(derive makeArbitrary ''IgnoreTermFrequency)
+$(derive makeArbitrary ''MinimumTermFrequency)
+$(derive makeArbitrary ''MaxQueryTerms)
+$(derive makeArbitrary ''Fuzziness)
+$(derive makeArbitrary ''PrefixLength)
+$(derive makeArbitrary ''TypeName)
+$(derive makeArbitrary ''PercentMatch)
+$(derive makeArbitrary ''StopWord)
+$(derive makeArbitrary ''QueryPath)
+$(derive makeArbitrary ''AllowLeadingWildcard)
+$(derive makeArbitrary ''LowercaseExpanded)
+$(derive makeArbitrary ''EnablePositionIncrements)
+$(derive makeArbitrary ''AnalyzeWildcard)
+$(derive makeArbitrary ''GeneratePhraseQueries)
+$(derive makeArbitrary ''Locale)
+$(derive makeArbitrary ''MaxWordLength)
+$(derive makeArbitrary ''MinWordLength)
+$(derive makeArbitrary ''PhraseSlop)
+$(derive makeArbitrary ''MinDocFrequency)
+$(derive makeArbitrary ''MaxDocFrequency)
+$(derive makeArbitrary ''Regexp)
+$(derive makeArbitrary ''Filter)
+$(derive makeArbitrary ''Query)
+$(derive makeArbitrary ''SimpleQueryStringQuery)
+$(derive makeArbitrary ''FieldOrFields)
+$(derive makeArbitrary ''SimpleQueryFlag)
+$(derive makeArbitrary ''RegexpQuery)
+$(derive makeArbitrary ''QueryStringQuery)
+$(derive makeArbitrary ''RangeQuery)
+$(derive makeArbitrary ''RangeValue)
+$(derive makeArbitrary ''PrefixQuery)
+$(derive makeArbitrary ''NestedQuery)
+$(derive makeArbitrary ''MoreLikeThisFieldQuery)
+$(derive makeArbitrary ''MoreLikeThisQuery)
+$(derive makeArbitrary ''IndicesQuery)
+$(derive makeArbitrary ''HasParentQuery)
+$(derive makeArbitrary ''HasChildQuery)
+$(derive makeArbitrary ''FuzzyQuery)
+$(derive makeArbitrary ''FuzzyLikeFieldQuery)
+$(derive makeArbitrary ''FuzzyLikeThisQuery)
+$(derive makeArbitrary ''FilteredQuery)
+$(derive makeArbitrary ''DisMaxQuery)
+$(derive makeArbitrary ''CommonTermsQuery)
+$(derive makeArbitrary ''DistanceRange)
+$(derive makeArbitrary ''MultiMatchQuery)
+$(derive makeArbitrary ''LessThanD)
+$(derive makeArbitrary ''LessThanEqD)
+$(derive makeArbitrary ''GreaterThanD)
+$(derive makeArbitrary ''GreaterThanEqD)
+$(derive makeArbitrary ''LessThan)
+$(derive makeArbitrary ''LessThanEq)
+$(derive makeArbitrary ''GreaterThan)
+$(derive makeArbitrary ''GreaterThanEq)
+$(derive makeArbitrary ''GeoPoint)
+$(derive makeArbitrary ''NullValue)
+$(derive makeArbitrary ''MinimumMatchHighLow)
+$(derive makeArbitrary ''CommonMinimumMatch)
+$(derive makeArbitrary ''BoostingQuery)
+$(derive makeArbitrary ''BoolQuery)
+$(derive makeArbitrary ''MatchQuery)
+$(derive makeArbitrary ''MultiMatchQueryType)
+$(derive makeArbitrary ''BooleanOperator)
+$(derive makeArbitrary ''ZeroTermsQuery)
+$(derive makeArbitrary ''MatchQueryType)
+$(derive makeArbitrary ''IndexAliasCreate)
+$(derive makeArbitrary ''SearchAliasRouting)
+$(derive makeArbitrary ''ScoreType)
+$(derive makeArbitrary ''Distance)
+$(derive makeArbitrary ''DistanceUnit)
+$(derive makeArbitrary ''DistanceType)
+$(derive makeArbitrary ''OptimizeBbox)
+$(derive makeArbitrary ''GeoBoundingBoxConstraint)
+$(derive makeArbitrary ''GeoFilterType)
+$(derive makeArbitrary ''GeoBoundingBox)
+$(derive makeArbitrary ''LatLon)
+$(derive makeArbitrary ''RangeExecution)
+$(derive makeArbitrary ''RegexpFlags)
+$(derive makeArbitrary ''RegexpFlag)
+$(derive makeArbitrary ''BoolMatch)
+$(derive makeArbitrary ''Term)
+
 
 main :: IO ()
 main = hspec $ do
@@ -869,3 +980,100 @@ main = hspec $ do
         regular_search `shouldBe` Right exampleTweet -- Check that the size restrtiction is being honored
       liftIO $
         scan_search `shouldMatchList` [Just exampleTweet, Just otherTweet]
+
+  describe "JSON instances" $ do
+    propJSON (Proxy :: Proxy Version)
+    propJSON (Proxy :: Proxy IndexName)
+    propJSON (Proxy :: Proxy MappingName)
+    propJSON (Proxy :: Proxy DocId)
+    propJSON (Proxy :: Proxy IndexAliasRouting)
+    propJSON (Proxy :: Proxy RoutingValue)
+    propJSON (Proxy :: Proxy ShardCount)
+    propJSON (Proxy :: Proxy ReplicaCount)
+    propJSON (Proxy :: Proxy TemplateName)
+    propJSON (Proxy :: Proxy TemplatePattern)
+    propJSON (Proxy :: Proxy QueryString)
+    propJSON (Proxy :: Proxy FieldName)
+    propJSON (Proxy :: Proxy CacheName)
+    propJSON (Proxy :: Proxy CacheKey)
+    propJSON (Proxy :: Proxy Existence)
+    propJSON (Proxy :: Proxy CutoffFrequency)
+    propJSON (Proxy :: Proxy Analyzer)
+    propJSON (Proxy :: Proxy MaxExpansions)
+    propJSON (Proxy :: Proxy Lenient)
+    propJSON (Proxy :: Proxy Tiebreaker)
+    propJSON (Proxy :: Proxy Boost)
+    propJSON (Proxy :: Proxy BoostTerms)
+    propJSON (Proxy :: Proxy MaxExpansions)
+    propJSON (Proxy :: Proxy MinimumMatch)
+    propJSON (Proxy :: Proxy DisableCoord)
+    propJSON (Proxy :: Proxy IgnoreTermFrequency)
+    propJSON (Proxy :: Proxy MinimumTermFrequency)
+    propJSON (Proxy :: Proxy MaxQueryTerms)
+    propJSON (Proxy :: Proxy Fuzziness)
+    propJSON (Proxy :: Proxy PrefixLength)
+    propJSON (Proxy :: Proxy TypeName)
+    propJSON (Proxy :: Proxy PercentMatch)
+    propJSON (Proxy :: Proxy StopWord)
+    propJSON (Proxy :: Proxy QueryPath)
+    propJSON (Proxy :: Proxy AllowLeadingWildcard)
+    propJSON (Proxy :: Proxy LowercaseExpanded)
+    propJSON (Proxy :: Proxy EnablePositionIncrements)
+    propJSON (Proxy :: Proxy AnalyzeWildcard)
+    propJSON (Proxy :: Proxy GeneratePhraseQueries)
+    propJSON (Proxy :: Proxy Locale)
+    propJSON (Proxy :: Proxy MaxWordLength)
+    propJSON (Proxy :: Proxy MinWordLength)
+    propJSON (Proxy :: Proxy PhraseSlop)
+    propJSON (Proxy :: Proxy MinDocFrequency)
+    propJSON (Proxy :: Proxy MaxDocFrequency)
+    propJSON (Proxy :: Proxy Filter)
+    propJSON (Proxy :: Proxy Query)
+    propJSON (Proxy :: Proxy SimpleQueryStringQuery)
+    propJSON (Proxy :: Proxy FieldOrFields)
+    propJSON (Proxy :: Proxy SimpleQueryFlag)
+    propJSON (Proxy :: Proxy RegexpQuery)
+    propJSON (Proxy :: Proxy QueryStringQuery)
+    propJSON (Proxy :: Proxy RangeQuery)
+    propJSON (Proxy :: Proxy PrefixQuery)
+    propJSON (Proxy :: Proxy NestedQuery)
+    propJSON (Proxy :: Proxy MoreLikeThisFieldQuery)
+    propJSON (Proxy :: Proxy MoreLikeThisQuery)
+    propJSON (Proxy :: Proxy IndicesQuery)
+    propJSON (Proxy :: Proxy HasParentQuery)
+    propJSON (Proxy :: Proxy HasChildQuery)
+    propJSON (Proxy :: Proxy FuzzyQuery)
+    propJSON (Proxy :: Proxy FuzzyLikeFieldQuery)
+    propJSON (Proxy :: Proxy FuzzyLikeThisQuery)
+    propJSON (Proxy :: Proxy FilteredQuery)
+    propJSON (Proxy :: Proxy DisMaxQuery)
+    propJSON (Proxy :: Proxy CommonTermsQuery)
+    propJSON (Proxy :: Proxy CommonMinimumMatch)
+    propJSON (Proxy :: Proxy BoostingQuery)
+    propJSON (Proxy :: Proxy BoolQuery)
+    propJSON (Proxy :: Proxy MatchQuery)
+    propJSON (Proxy :: Proxy MultiMatchQueryType)
+    propJSON (Proxy :: Proxy BooleanOperator)
+    propJSON (Proxy :: Proxy ZeroTermsQuery)
+    propJSON (Proxy :: Proxy MatchQueryType)
+    propJSON (Proxy :: Proxy AliasRouting)
+    propJSON (Proxy :: Proxy IndexAliasCreate)
+    propJSON (Proxy :: Proxy SearchAliasRouting)
+    propJSON (Proxy :: Proxy ScoreType)
+    propJSON (Proxy :: Proxy Distance)
+    propJSON (Proxy :: Proxy DistanceUnit)
+    propJSON (Proxy :: Proxy DistanceType)
+    propJSON (Proxy :: Proxy OptimizeBbox)
+    propJSON (Proxy :: Proxy GeoBoundingBoxConstraint)
+    propJSON (Proxy :: Proxy GeoFilterType)
+    propJSON (Proxy :: Proxy GeoBoundingBox)
+    propJSON (Proxy :: Proxy LatLon)
+    propJSON (Proxy :: Proxy RangeExecution)
+    prop "RegexpFlags FromJSON/ToJSON roundtrips, removing dups " $ \rfs ->
+      let expected = case rfs of
+                       SomeRegexpFlags fs -> SomeRegexpFlags (NE.fromList (nub (NE.toList fs)))
+                       x -> x
+      in parseEither parseJSON (toJSON rfs) === Right expected
+    propJSON (Proxy :: Proxy BoolMatch)
+    propJSON (Proxy :: Proxy Term)
+    propJSON (Proxy :: Proxy MultiMatchQuery)


### PR DESCRIPTION
This is in reference to #79 and is meant for review. Apologies for the size and duration of the PR but most of the work was due to me pulling the string on the fact that aliases can include filters, which can include queries, so I had to add FromJSON instances for all of that.

A couple discussion points:
1. `getIndexAliases` seems like its the first case where its purely a GET operation with a non-trivial response type. I went with a response type of `Either EsError IndexAliases` and exported the utility function `parseEsResponse` to capture the case that all JSON responses should either parse as the intended type or EsError. Do note that this function does throw in the (AFAIK impossible) case that the response doesn't parse as either. At least it documents what it throws...
2. There are some breaking changes to the types. I chose to test the JSON instances via quickcheck and caught some bugs and ambiguities that the types allowed. A lot of them are from combining lists and maybe, where there is no semantic difference between `Nothing` and `Just []`. In those cases I updated it to `Maybe (NonEmpty a)`. The full list of broken changes can be provided in the changelog if desired. These breaking changes should be really easy to fix for end users though, especially since Bloodhound uses NonEmpty in other places.
3. I get some doctest errors on my machine. We'll see if travis has the same issue.