### PR TITLE
Add Request hook

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -27,6 +27,7 @@ library
                        Database.Bloodhound.Client
                        Database.Bloodhound.Types
                        Database.Bloodhound.Types.Class
+                       Database.Bloodhound.Types.Internal
   hs-source-dirs:      src
   build-depends:       base             >= 4.3     && <5,
                        bytestring       >= 0.10.0  && <0.11,

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -776,7 +776,7 @@ statusCheck prd = prd . NHTS.statusCode . responseStatus
 -- this option only be used over an SSL connection.
 --
 -- >> (mkBHEnv myServer myManager) { bhRequestHook = basicAuthHook (EsUsername "myuser") (EsPassword "mypass") }
-basicAuthHook :: EsUsername -> EsPassword -> Request -> IO Request
+basicAuthHook :: Monad m => EsUsername -> EsPassword -> Request -> m Request
 basicAuthHook (EsUsername u) (EsPassword p) = return . applyBasicAuth u' p'
   where u' = T.encodeUtf8 u
         p' = T.encodeUtf8 p

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -57,6 +57,8 @@ module Database.Bloodhound.Client
        , getStatus
        , encodeBulkOperations
        , encodeBulkOperation
+       -- * Authentication
+       , basicAuthHook
        -- * Reply-handling tools
        , isVersionConflict
        , isSuccess
@@ -767,3 +769,14 @@ isCreated = statusCheck (== 201)
 
 statusCheck :: (Int -> Bool) -> Reply -> Bool
 statusCheck prd = prd . NHTS.statusCode . responseStatus
+
+-- | This is a hook that can be set via the 'bhRequestHook' function
+-- that will authenticate all requests using an HTTP Basic
+-- Authentication header. Note that it is *strongly* recommended that
+-- this option only be used over an SSL connection.
+--
+-- >> (mkBHEnv myServer myManager) { bhRequestHook = basicAuthHook (EsUsername "myuser") (EsPassword "mypass") }
+basicAuthHook :: EsUsername -> EsPassword -> Request -> IO Request
+basicAuthHook (EsUsername u) (EsPassword p) = return . applyBasicAuth u' p'
+  where u' = T.encodeUtf8 u
+        p' = T.encodeUtf8 p

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -176,9 +176,9 @@ dispatch dMethod url body = do
   initReq <- liftIO $ parseUrl' url
   reqHook <- bhRequestHook <$> getBHEnv
   let reqBody = RequestBodyLBS $ fromMaybe emptyBody body
-  req <- reqHook $ initReq { method = dMethod
-                           , requestBody = reqBody
-                           , checkStatus = \_ _ _ -> Nothing}
+  req <- liftIO $ reqHook $ initReq { method = dMethod
+                                    , requestBody = reqBody
+                                    , checkStatus = \_ _ _ -> Nothing}
   mgr <- bhManager <$> getBHEnv
   liftIO $ httpLbs req mgr
 

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -262,6 +262,9 @@ module Database.Bloodhound.Types
        , TermsResult(..)
        , DateHistogramResult(..)
        , DateRangeResult(..)
+
+       , EsUsername(..)
+       , EsPassword(..)
          ) where
 
 import           Control.Applicative
@@ -3533,3 +3536,9 @@ instance Enum DocVersion where
   fromEnum = docVersionNumber
   enumFrom = boundedEnumFrom
   enumFromThen = boundedEnumFromThen
+
+-- | Username type used for HTTP Basic authentication. See 'basicAuthHook'.
+newtype EsUsername = EsUsername { esUsername :: Text } deriving (Show, Eq)
+
+-- | Password type used for HTTP Basic authentication. See 'basicAuthHook'.
+newtype EsPassword = EsPassword { esPassword :: Text } deriving (Show, Eq)

--- a/src/Database/Bloodhound/Types/Internal.hs
+++ b/src/Database/Bloodhound/Types/Internal.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RankNTypes                 #-}
 
 -------------------------------------------------------------------------------
 -- |
@@ -34,7 +33,7 @@ import           Network.HTTP.Client
 -}
 data BHEnv = BHEnv { bhServer      :: Server
                    , bhManager     :: Manager
-                   , bhRequestHook :: forall m. (MonadBH m) => Request -> m Request
+                   , bhRequestHook :: Request -> IO Request
                    -- ^ Low-level hook that is run before every request is sent. Used to implement custom authentication strategies. Defaults to 'return' with 'mkBHEnv'.
                    }
 

--- a/src/Database/Bloodhound/Types/Internal.hs
+++ b/src/Database/Bloodhound/Types/Internal.hs
@@ -8,7 +8,7 @@
 -- Module : Database.Bloodhound.Types.Internal
 -- Copyright : (C) 2014 Chris Allen
 -- License : BSD-style (see the file LICENSE)
--- Maintainer : Chris Allen <cma@bitemyapp.com
+-- Maintainer : Chris Allen <cma@bitemyapp.com>
 -- Stability : provisional
 -- Portability : DeriveGeneric, RecordWildCards
 --

--- a/src/Database/Bloodhound/Types/Internal.hs
+++ b/src/Database/Bloodhound/Types/Internal.hs
@@ -22,6 +22,7 @@ module Database.Bloodhound.Types.Internal
     ) where
 
 
+import           Control.Applicative
 import           Control.Monad.Reader
 import           Data.Text            (Text)
 import           Data.Typeable        (Typeable)

--- a/src/Database/Bloodhound/Types/Internal.hs
+++ b/src/Database/Bloodhound/Types/Internal.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
+
+-------------------------------------------------------------------------------
+-- |
+-- Module : Database.Bloodhound.Types.Internal
+-- Copyright : (C) 2014 Chris Allen
+-- License : BSD-style (see the file LICENSE)
+-- Maintainer : Chris Allen <cma@bitemyapp.com
+-- Stability : provisional
+-- Portability : DeriveGeneric, RecordWildCards
+--
+-- Internal data types for Bloodhound. These types may change without
+-- notice so import at your own risk.
+-------------------------------------------------------------------------------
+module Database.Bloodhound.Types.Internal
+    ( BHEnv(..)
+    , Server(..)
+    , MonadBH(..)
+    ) where
+
+
+import           Control.Monad.Reader
+import           Data.Text            (Text)
+import           Data.Typeable        (Typeable)
+import           GHC.Generics         (Generic)
+import           Network.HTTP.Client
+
+{-| Common environment for Elasticsearch calls. Connections will be
+    pipelined according to the provided HTTP connection manager.
+-}
+data BHEnv = BHEnv { bhServer      :: Server
+                   , bhManager     :: Manager
+                   , bhRequestHook :: forall m. (MonadBH m) => Request -> m Request
+                   -- ^ Low-level hook that is run before every request is sent. Used to implement custom authentication strategies. Defaults to 'return' with 'mkBHEnv'.
+                   }
+
+instance (Functor m, Applicative m, MonadIO m) => MonadBH (ReaderT BHEnv m) where
+  getBHEnv = ask
+
+{-| 'Server' is used with the client functions to point at the ES instance
+-}
+newtype Server = Server Text deriving (Eq, Show, Generic, Typeable)
+
+{-| All API calls to Elasticsearch operate within
+    MonadBH
+    . The idea is that it can be easily embedded in your
+    own monad transformer stack. A default instance for a ReaderT and
+    alias 'BH' is provided for the simple case.
+-}
+class (Functor m, Applicative m, MonadIO m) => MonadBH m where
+  getBHEnv :: m BHEnv
+

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -238,7 +238,7 @@ searchExpectNoResults search = do
 
 searchExpectAggs :: Search -> BH IO ()
 searchExpectAggs search = do
-  reply <- searchAll search
+  reply <- searchByIndex testIndex search
   let isEmpty x = return (M.null x)
   let result = decode (responseBody reply) :: Maybe (SearchResult Tweet)
   liftIO $
@@ -247,7 +247,7 @@ searchExpectAggs search = do
 searchValidBucketAgg :: (BucketAggregation a, FromJSON a, Show a) =>
                         Search -> Text -> (Text -> AggregationResults -> Maybe (Bucket a)) -> BH IO ()
 searchValidBucketAgg search aggKey extractor = do
-  reply <- searchAll search
+  reply <- searchByIndex testIndex search
   let bucketDocs = docCount . head . buckets
   let result = decode (responseBody reply) :: Maybe (SearchResult Tweet)
   let count = result >>= aggregations >>= extractor aggKey >>= \x -> return (bucketDocs x)
@@ -272,8 +272,8 @@ searchExpectSource src expected = do
   _ <- insertData
   let query = QueryMatchQuery $ mkMatchQuery (FieldName "_all") (QueryString "haskell")
   let search = (mkSearch (Just query) Nothing) { source = Just src }
-  reply <- searchAll search
-  result <- parseEsResponse reply--  :: Either EsError (SearchResult Value)
+  reply <- searchByIndex testIndex search
+  result <- parseEsResponse reply
   let value = grabFirst result
   liftIO $
     value `shouldBe` expected


### PR DESCRIPTION
This is pretty much exactly as we discussed but with one difference: rather than having the request hook be in MonadBH m, its in IO. While dogfooding my own solution, I tried making the hook `forall m. MonadBH m => Request -> m Request` and it gave me some really nasty type inference issues. I didn't fret too much about switching to IO because there are two use cases for these hooks that I'm aware of:

1. HTTP Basic auth for ElasticSearch Shield.
2. Amazon request signing.

Both can happen in IO, and HTTP Basic doesn't even need that. If a user has to do something fancier, they'll likely be operating in their own ReaderT-based monad and can just `ask` the state and run their hook in IO.

I've documented things but I don't really see any way to test this because the standard distribution of ES won't expect or care about auth headers so we wouldn't be able to test it without adding a build matrix dimension that sets up shield and user roles. The tests do show that the identity hook doesn't break anything and I have code running in production using [bloodhound-amazonka-auth](https://github.com/MichaelXavier/bloodhound-amazonka-auth) and its working great.