### PR TITLE
Support Bool and Numeric keys in TermsResults

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -42,6 +42,7 @@ library
                        transformers     >= 0.2     && <0.5,
                        http-types       >= 0.8     && <0.10,
                        vector           >= 0.10.9  && <0.12,
+                       scientific       >= 0.3.0.0 && <0.4.0.0,
                        exceptions,
                        data-default-class,
                        blaze-builder,

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -1802,11 +1802,11 @@ instance FromJSON BucketValue where
   parseJSON _ = mempty
 
 instance FromJSON TermsResult where
-  parseJSON = withObject "TermsResult" $ \o -> do
-    termKey <- o .: "key"
-    termsDocCount <- o .: "doc_count"
-    termsAggs <- o .:?  "aggregations"
-    return TermsResult{..}
+  parseJSON (Object v) = TermsResult <$>
+                         v .:   "key"       <*>
+                         v .:   "doc_count" <*>
+                         v .:?  "aggregations"
+  parseJSON _ = mempty
 
 instance FromJSON DateHistogramResult where
   parseJSON (Object v) = DateHistogramResult   <$>

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -1739,7 +1739,7 @@ instance ToJSON DateMathExpr where
 type AggregationResults = M.Map Text Value
 
 class BucketAggregation a where
-  key :: a -> Text
+  key :: a -> BucketValue
   docCount :: a -> Int
   aggs :: a -> Maybe AggregationResults
 
@@ -1776,19 +1776,17 @@ toDateHistogram t a = M.lookup t a >>= deserialize
   where deserialize = parseMaybe parseJSON
 
 instance BucketAggregation TermsResult where
-  key (TermsResult (TextValue t) _ _) = t
-  key (TermsResult (ScientificValue s) _ _) = T.pack $ show s
-  key (TermsResult (BoolValue b) _ _) = T.pack $ show b
+  key = termKey
   docCount = termsDocCount
   aggs = termsAggs
 
 instance BucketAggregation DateHistogramResult where
-  key = showText . dateKey
+  key = TextValue . showText . dateKey
   docCount = dateDocCount
   aggs = dateHistogramAggs
 
 instance BucketAggregation DateRangeResult where
-  key = dateRangeKey
+  key = TextValue . dateRangeKey
   docCount = dateRangeDocCount
   aggs = dateRangeAggs
 


### PR DESCRIPTION
Addresses https://github.com/bitemyapp/bloodhound/issues/88

This is a backwards-incompatible change because the type of the `termKey` record in `TermsResult` and the signature of `BucketAggregation.key` have changed.

Some things I'm not sure about:
1) What is the `BucketAggregation` class used for? Is it okay to just convert `Scientific` and `Bool` keys to `Text`?
2) I'm a little concerned about the `Scientific` `Show` instance.  A JSON integer, `123` for example, will display as "123.0" as a `Scientific`. Is this acceptable?

Edit: reflect new content