### PR TITLE
make respIsTwoHunna more semantic

### DIFF
--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -309,11 +309,11 @@ deepMerge = LS.foldl' go mempty
         merge _ b = b
 
 
-statusCodeIs :: Int -> Reply -> Bool
-statusCodeIs n resp = NHTS.statusCode (responseStatus resp) == n
+statusCodeIs :: (Int, Int) -> Reply -> Bool
+statusCodeIs r resp = inRange r $ NHTS.statusCode (responseStatus resp)
 
 respIsTwoHunna :: Reply -> Bool
-respIsTwoHunna = statusCodeIs 200
+respIsTwoHunna = statusCodeIs (200, 299)
 
 existentialQuery :: MonadBH m => Text -> m (Reply, Bool)
 existentialQuery url = do


### PR DESCRIPTION
Don't mind the branch name, I got lazy.

This is actually the cause of a bug in real code. If you happen to be
using parseEsResponse (which uses respIsTwoHunna) to parse the result of
certain operations such as creating an index, those operations return a
201 and unjustly are deemed to be a failure. I will not disclose how
long this took me to figure out the true cause ;)