### PR TITLE
Add Missing Aggregation support

### DIFF
--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -237,6 +237,7 @@ module Database.Bloodhound.Types
        , Bucket(..)
        , BucketAggregation(..)
        , TermsAggregation(..)
+       , MissingAggregation(..)
        , ValueCountAggregation(..)
        , FilterAggregation(..)
        , DateHistogramAggregation(..)
@@ -1544,8 +1545,12 @@ data Aggregation = TermsAgg TermsAggregation
                  | DateHistogramAgg DateHistogramAggregation
                  | ValueCountAgg ValueCountAggregation
                  | FilterAgg FilterAggregation
-                 | DateRangeAgg DateRangeAggregation deriving (Eq, Show, Generic, Typeable)
+                 | DateRangeAgg DateRangeAggregation
+                 | MissingAgg MissingAggregation deriving (Eq, Show, Generic, Typeable)
 
+data MissingAggregation = MissingAggregation
+  { maField :: Text
+  } deriving (Eq, Show, Generic, Typeable)
 
 data TermsAggregation = TermsAggregation { term              :: Either Text Text
                                          , termInclude       :: Maybe TermInclusion
@@ -1705,6 +1710,8 @@ instance ToJSON Aggregation where
               , "aggs" .= ags]
   toJSON (DateRangeAgg a) = object [ "date_range" .= a
                                    ]
+  toJSON (MissingAgg (MissingAggregation{..})) =
+    object ["missing" .= object ["field" .= maField]]
 
 instance ToJSON DateRangeAggregation where
   toJSON DateRangeAggregation {..} =


### PR DESCRIPTION
Addresses https://github.com/bitemyapp/bloodhound/issues/99

I would write a test for this, but I've been unable to get the tests to run locally.
1) `cabal install -j --only-dependencies --enable-tests` outputs this error:
```
src/Test/Hspec/Core/Type.hs:152:20:
    Constructor ‘HUnitFailure’ should have 2 arguments, but has been given 1
    In the pattern: HUnitFailure err
    In the first argument of ‘E.Handler’, namely
      ‘(\ (HUnitFailure err) -> return (Fail err))’
    In the expression:
      E.Handler (\ (HUnitFailure err) -> return (Fail err))
```

2) To fix the above error, I update the `hspec` bounds in `bloodhound.cabal` from `>= 1.8 && <2.2` to `>= 2.0 && <2.2`

3) Moving to hspec 2.0 causes this error:
```
tests/tests.hs:488:10:
    Duplicate instance declarations:
      instance (Arbitrary k, Ord k, Arbitrary v) => Arbitrary (M.Map k v)
        -- Defined at tests/tests.hs:488:10
      instance [overlap ok] [safe] (Ord k, Arbitrary k, Arbitrary v) =>
                                   Arbitrary (M.Map k v)
        -- Defined in ‘Test.QuickCheck.Arbitrary’
```
I fix it by removing that `Arbitrary` instance.

4) I reinstall and build. When I run `cabal tests` I get the message `You need to re-run the 'configure' command. The version of Cabal being used has changed (was Cabal-1.18.1.3, now Cabal-1.23.0.0).`

5) I run `cabal configure --enable-tests` and re-run `cabal tests`, but it doesn't make a difference.

Edit: Add bit about `Arbitrary`