### PR TITLE
Add local testing instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Stability
 
 Bloodhound is stable for production use. I will strive to avoid breaking API compatibility from here on forward, but dramatic features like a type-safe, fully integrated mapping API may require breaking things in the future.
 
+Testing
+---------
+
+The TravisCI tests are run using [Stack](http://docs.haskellstack.org/en/stable/README.html). You should use Stack instead of `cabal` to build and test Bloodhound to avoid compatibility problems. You will also need to have an ElasticSearch instance running at `localhost:9200` in order to execute some of the tests. See the "Version compatibility" section above for a list of ElasticSearch versions that are officially validated against in TravisCI.
+
+Steps to run the tests locally:
+  1. Dig through the [past releases] (https://www.elastic.co/downloads/past-releases) section of the ElasticSearch download page and install the desired ElasticSearch versions.
+  2. Install [Stack] (http://docs.haskellstack.org/en/stable/README.html#how-to-install)
+  3. In your local Bloodhound directory, run `stack setup && stack build`
+  4. Start the desired version of ElasticSearch at `localhost:9200`, which should be the default.
+  5. Run `stack test` in your local Bloodhound directory.
+  6. The unit tests will pass if you re-execute `stack test`, but some of the doctests might fail due to existing data in ElasticSearch. If you want to start with a clean slate, stop your ElasticSearch instance, delete the `data/` folder in the ElasticSearch installation, restart ElasticSearch, and re-run `stack test`.
+
+
 Hackage page and Haddock documentation
 ======================================
 


### PR DESCRIPTION
1) I noticed that the README says that TravisCI tests against `1.0.3, 1.1.2, 1.2.3, 1.3.2, and 1.4.0`, but if you look in TravisCI itself, the versions are `1.2.4, 1.3.6, 1.4.1, 1.5.2, 1.6.0, and 1.7.2`. Is the README out of date?

2) What are the `es14` etc functions for in [tests.hs] (https://github.com/bitemyapp/bloodhound/blob/master/tests/tests.hs#L69)?