### PR TITLE
Doh, need to export BucketValue

### DIFF
--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -238,6 +238,7 @@ module Database.Bloodhound.Types
        , Aggregation(..)
        , Aggregations
        , AggregationResults
+       , BucketValue(..)
        , Bucket(..)
        , BucketAggregation(..)
        , TermsAggregation(..)


### PR DESCRIPTION
Now that I've picked up the latest content via our own vendor version...I realize that I forgot to export `BucketValue`! :cry: 