### PR TITLE
Add helper data types and functions for Missing Aggregations

### DIFF
--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -1814,15 +1814,16 @@ data DateRangeResult = DateRangeResult { dateRangeKey          :: Text
                                        , dateRangeAggs         :: Maybe AggregationResults } deriving (Show, Eq, Generic, Typeable)
 
 toTerms :: Text -> AggregationResults ->  Maybe (Bucket TermsResult)
-toTerms t a = M.lookup t a >>= deserialize
-  where deserialize = parseMaybe parseJSON
+toTerms = toAggResult
 
 toDateHistogram :: Text -> AggregationResults -> Maybe (Bucket DateHistogramResult)
-toDateHistogram t a = M.lookup t a >>= deserialize
-  where deserialize = parseMaybe parseJSON
+toDateHistogram = toAggResult
 
 toMissing :: Text -> AggregationResults -> Maybe MissingResult
-toMissing t a = M.lookup t a >>= deserialize
+toMissing = toAggResult
+
+toAggResult :: (FromJSON a) => Text -> AggregationResults -> Maybe a
+toAggResult t a = M.lookup t a >>= deserialize
   where deserialize = parseMaybe parseJSON
 
 instance BucketAggregation TermsResult where

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -47,6 +47,7 @@ module Database.Bloodhound.Types
        , mkDateHistogram
        , mkDocVersion
        , docVersionNumber
+       , toMissing
        , toTerms
        , toDateHistogram
        , omitNulls
@@ -265,6 +266,7 @@ module Database.Bloodhound.Types
        , HighlightTag(..)
        , HitHighlight
 
+       , MissingResult(..)
        , TermsResult(..)
        , DateHistogramResult(..)
        , DateRangeResult(..)
@@ -1792,6 +1794,8 @@ data BucketValue = TextValue Text
                  | ScientificValue Scientific
                  | BoolValue Bool deriving (Show)
 
+data MissingResult = MissingResult { missingDocCount :: Int } deriving (Show)
+
 data TermsResult = TermsResult { termKey       :: BucketValue
                                , termsDocCount :: Int
                                , termsAggs     :: Maybe AggregationResults } deriving (Show)
@@ -1815,6 +1819,10 @@ toTerms t a = M.lookup t a >>= deserialize
 
 toDateHistogram :: Text -> AggregationResults -> Maybe (Bucket DateHistogramResult)
 toDateHistogram t a = M.lookup t a >>= deserialize
+  where deserialize = parseMaybe parseJSON
+
+toMissing :: Text -> AggregationResults -> Maybe MissingResult
+toMissing t a = M.lookup t a >>= deserialize
   where deserialize = parseMaybe parseJSON
 
 instance BucketAggregation TermsResult where
@@ -1842,6 +1850,10 @@ instance FromJSON BucketValue where
   parseJSON (Number s) = return $ ScientificValue s
   parseJSON (Bool b) = return $ BoolValue b
   parseJSON _ = mempty
+
+instance FromJSON MissingResult where
+  parseJSON = withObject "MissingResult" parse
+    where parse v = MissingResult <$> v .: "doc_count"
 
 instance FromJSON TermsResult where
   parseJSON (Object v) = TermsResult <$>


### PR DESCRIPTION
It's funny what you discover once you start eating your own dog food =)

Add the `MissingResult` data type (akin to `TermsResult`) and `toMissing` helper function for parsing `MissingResults` from `AggregationResults`.