### PR TITLE
Aeson lower bound loosening

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -1,5 +1,5 @@
 name:                bloodhound
-version:             0.11.0.0
+version:             0.11.0.1
 synopsis:            ElasticSearch client library for Haskell
 description:         ElasticSearch made awesome for Haskell hackers
 homepage:            https://github.com/bitemyapp/bloodhound
@@ -32,7 +32,7 @@ library
   build-depends:       base             >= 4.3     && <5,
                        bytestring       >= 0.10.0  && <0.11,
                        containers       >= 0.5.0.0 && <0.6,
-                       aeson            >= 0.11.1  && <0.12,
+                       aeson            >= 0.8 && < 0.10 || == 0.11.*
                        http-client      >= 0.3     && <0.5,
                        network-uri      >= 2.6     && <2.7,
                        semigroups       >= 0.15    && <0.19,

--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -32,7 +32,7 @@ library
   build-depends:       base             >= 4.3     && <5,
                        bytestring       >= 0.10.0  && <0.11,
                        containers       >= 0.5.0.0 && <0.6,
-                       aeson            >= 0.8 && < 0.10 || == 0.11.*
+                       aeson            >= 0.8 && < 0.10 || == 0.11.*,
                        http-client      >= 0.3     && <0.5,
                        network-uri      >= 2.6     && <2.7,
                        semigroups       >= 0.15    && <0.19,


### PR DESCRIPTION
Since the latest `aeson` isn't on stackage yet, can we loosen the lower bounds of bloodhound to account for all packages `>= 0.8 && < 12`, excluding the problematic `0.10.0.0`

Unless you have an explicit reason to avoid versions `0.8` and `0.9` I don't see why we shouldn't allow them to be used (`0.9` is currently on stackage)

Or, would you want to put `bloodhound` on stackage ? :) 

