### PR TITLE
Fix Haddocks italicizing forward slashes

### DIFF
--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -591,7 +591,7 @@ deleteDocument (IndexName indexName)
 -- | 'bulk' uses
 --    <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html Elasticsearch's bulk API>
 --    to perform bulk operations. The 'BulkOperation' data type encodes the
---    index/update/delete/create operations. You pass a 'V.Vector' of 'BulkOperation's
+--    index\/update\/delete\/create operations. You pass a 'V.Vector' of 'BulkOperation's
 --    and a 'Server' to 'bulk' in order to send those operations up to your Elasticsearch
 --    server to be performed. I changed from [BulkOperation] to a Vector due to memory overhead.
 --


### PR DESCRIPTION
The haddocks are currently reading the forward slashes to mean to italicize:

![image](https://cloud.githubusercontent.com/assets/1274145/14590544/e8a48342-04b1-11e6-8f17-8ec165a487e4.png)
