### PR TITLE
Set minimum lower bound on http-client

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -33,7 +33,7 @@ library
                        bytestring       >= 0.10.0  && <0.11,
                        containers       >= 0.5.0.0 && <0.6,
                        aeson            >= 0.11.1  && <0.12,
-                       http-client      >= 0.5     && <0.6,
+                       http-client      >= 0.4.30  && <0.6,
                        network-uri      >= 2.6     && <2.7,
                        semigroups       >= 0.15    && <0.19,
                        time             >= 1.4     && <1.7,

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -2,7 +2,6 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-# - http-client-0.4.24
 - http-client-0.5.0
 - aeson-0.11.1.0
 - fail-4.9.0.0


### PR DESCRIPTION
There were either some functions removed in the http-client 0.4 line or
ones added in 0.5 but after binary searching the version range, 0.4.30
seems to be the magic number where everything compiles and the tests
pass without having to do any CPP or worse.