### PR TITLE
Nodes api

### DIFF
--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -92,34 +92,32 @@ module Database.Bloodhound.Client
        )
        where
 
-import qualified Blaze.ByteString.Builder           as BB
-import           Control.Applicative                as A
+import qualified Blaze.ByteString.Builder     as BB
+import           Control.Applicative          as A
 import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Data.Aeson
 import           Data.ByteString.Lazy.Builder
-import qualified Data.ByteString.Lazy.Char8         as L
-import           Data.Foldable                      (toList)
-import qualified Data.HashMap.Strict                as HM
+import qualified Data.ByteString.Lazy.Char8   as L
+import           Data.Foldable                (toList)
+import qualified Data.HashMap.Strict          as HM
 import           Data.Ix
-import qualified Data.List                          as LS (filter, foldl')
-import           Data.List.NonEmpty                 (NonEmpty (..))
-import           Data.Maybe                         (catMaybes, fromMaybe,
-                                                     isJust)
+import qualified Data.List                    as LS (filter, foldl')
+import           Data.List.NonEmpty           (NonEmpty (..))
+import           Data.Maybe                   (catMaybes, fromMaybe, isJust)
 import           Data.Monoid
-import           Data.Text                          (Text)
-import qualified Data.Text                          as T
-import qualified Data.Text.Encoding                 as T
+import           Data.Text                    (Text)
+import qualified Data.Text                    as T
+import qualified Data.Text.Encoding           as T
 import           Data.Time.Clock
-import qualified Data.Vector                        as V
-import Debug.Trace
+import qualified Data.Vector                  as V
 import           Network.HTTP.Client
-import qualified Network.HTTP.Types.Method          as NHTM
-import qualified Network.HTTP.Types.Status          as NHTS
-import qualified Network.HTTP.Types.URI             as NHTU
-import qualified Network.URI                        as URI
-import           Prelude                            hiding (filter, head)
+import qualified Network.HTTP.Types.Method    as NHTM
+import qualified Network.HTTP.Types.Status    as NHTS
+import qualified Network.HTTP.Types.URI       as NHTU
+import qualified Network.URI                  as URI
+import           Prelude                      hiding (filter, head)
 
 import           Database.Bloodhound.Types
 
@@ -590,13 +588,13 @@ parseEsResponse :: (MonadThrow m, FromJSON a) => Reply
 parseEsResponse reply
   | respIsTwoHunna reply = case eitherDecode body of
                              Right a -> return (Right a)
-                             Left e -> traceShow e tryParseError
+                             Left _ -> tryParseError
   | otherwise = tryParseError
   where body = responseBody reply
         tryParseError = case eitherDecode body of
                           Right e -> return (Left e)
                           -- this case should not be possible
-                          Left e -> traceShow e explode
+                          Left _ -> explode
         explode = throwM (EsProtocolException body)
 
 -- | 'indexExists' enables you to check if an index exists. Returns 'Bool'

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -3892,7 +3892,7 @@ data NodeHTTPInfo = NodeHTTPInfo {
     } deriving (Eq, Show, Generic, Typeable)
 
 data NodeTransportInfo = NodeTransportInfo {
-      nodeTransportProfiles :: [BoundTransportAddress] --TODO: bound transport/publish addresses, paper over NULL meaning []
+      nodeTransportProfiles :: [BoundTransportAddress]
     , nodeTransportAddress  :: BoundTransportAddress
     } deriving (Eq, Show, Generic, Typeable)
 
@@ -3952,7 +3952,7 @@ data ThreadPoolSize = ThreadPoolBounded Int
 
 data ThreadPoolType = ThreadPoolScaling
                     | ThreadPoolFixed
-                    | ThreadPoolCached --TODO: are there others
+                    | ThreadPoolCached
                     deriving (Eq, Show, Generic, Typeable)
 
 data NodeJVMInfo = NodeJVMInfo {
@@ -3964,7 +3964,7 @@ data NodeJVMInfo = NodeJVMInfo {
     , nodeJVMVMVersion                   :: VersionNumber
     -- ^ JVM doesn't seme to follow normal version conventions
     , nodeJVMVMName                      :: Text
-    , nodeJVMVersion                     :: VersionNumber --TODO: normalize underscores
+    , nodeJVMVersion                     :: VersionNumber
     , nodeJVMPID                         :: PID
     } deriving (Eq, Show, Generic, Typeable)
 

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -3922,8 +3922,8 @@ data NodeThreadPoolsInfo = NodeThreadPoolsInfo {
       nodeThreadPoolsRefresh           :: NodeThreadPoolInfo
     , nodeThreadPoolsManagement        :: NodeThreadPoolInfo
     , nodeThreadPoolsPercolate         :: NodeThreadPoolInfo
-    , nodeThreadPoolsListener          :: NodeThreadPoolInfo
-    , nodeThreadPoolsFetchShardStarted :: NodeThreadPoolInfo
+    , nodeThreadPoolsListener          :: Maybe NodeThreadPoolInfo
+    , nodeThreadPoolsFetchShardStarted :: Maybe NodeThreadPoolInfo
     , nodeThreadPoolsSearch            :: NodeThreadPoolInfo
     , nodeThreadPoolsFlush             :: NodeThreadPoolInfo
     , nodeThreadPoolsWarmer            :: NodeThreadPoolInfo
@@ -3933,7 +3933,7 @@ data NodeThreadPoolsInfo = NodeThreadPoolsInfo {
     , nodeThreadPoolsMerge             :: NodeThreadPoolInfo
     , nodeThreadPoolsSnapshot          :: NodeThreadPoolInfo
     , nodeThreadPoolsGet               :: NodeThreadPoolInfo
-    , nodeThreadPoolsFetchShardStore   :: NodeThreadPoolInfo
+    , nodeThreadPoolsFetchShardStore   :: Maybe NodeThreadPoolInfo
     , nodeThreadPoolsIndex             :: NodeThreadPoolInfo
     , nodeThreadPoolsGeneric           :: NodeThreadPoolInfo
     } deriving (Eq, Show, Generic, Typeable)
@@ -4467,8 +4467,8 @@ instance FromJSON NodeThreadPoolsInfo where
       parse o = NodeThreadPoolsInfo <$> o .: "refresh"
                                     <*> o .: "management"
                                     <*> o .: "percolate"
-                                    <*> o .: "listener"
-                                    <*> o .: "fetch_shard_started"
+                                    <*> o .:? "listener"
+                                    <*> o .:? "fetch_shard_started"
                                     <*> o .: "search"
                                     <*> o .: "flush"
                                     <*> o .: "warmer"
@@ -4478,7 +4478,7 @@ instance FromJSON NodeThreadPoolsInfo where
                                     <*> o .: "merge"
                                     <*> o .: "snapshot"
                                     <*> o .: "get"
-                                    <*> o .: "fetch_shard_store"
+                                    <*> o .:? "fetch_shard_store"
                                     <*> o .: "index"
                                     <*> o .: "generic"
 
@@ -4532,7 +4532,7 @@ instance FromJSON ThreadPoolType where
 instance FromJSON NodeTransportInfo where
   parseJSON = withObject "NodeTransportInfo" parse
     where
-      parse o = NodeTransportInfo <$> (parseProfiles =<< o .: "profiles")
+      parse o = NodeTransportInfo <$> (maybe (return mempty) parseProfiles =<< o .:? "profiles")
                                   <*> parseJSON (Object o)
       parseProfiles (Object o) | HM.null o = return []
       parseProfiles v@(Array _) = parseJSON v

--- a/src/Database/Bloodhound/Types/Internal.hs
+++ b/src/Database/Bloodhound/Types/Internal.hs
@@ -24,6 +24,7 @@ module Database.Bloodhound.Types.Internal
 
 import           Control.Applicative  as A
 import           Control.Monad.Reader
+import           Data.Aeson
 import           Data.Text            (Text)
 import           Data.Typeable        (Typeable)
 import           GHC.Generics         (Generic)
@@ -43,7 +44,7 @@ instance (Functor m, Applicative m, MonadIO m) => MonadBH (ReaderT BHEnv m) wher
 
 {-| 'Server' is used with the client functions to point at the ES instance
 -}
-newtype Server = Server Text deriving (Eq, Show, Generic, Typeable)
+newtype Server = Server Text deriving (Eq, Show, Generic, Typeable, FromJSON)
 
 {-| All API calls to Elasticsearch operate within
     MonadBH

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -1573,7 +1573,6 @@ main = hspec $ do
          -- parsing. Node info is so variable, there's not much I can
          -- assert here.
          Right NodesInfo {..} -> length nodesInfo `shouldBe` 1
-           --TODO: more assertions if possible
          Left e -> expectationFailure ("Expected NodesInfo but got " <> show e)
 
   describe "Enum DocVersion" $ do

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -1565,6 +1565,17 @@ main = hspec $ do
                 liftIO (exists `shouldBe` True)
           go `finally` deleteIndex expectedIndex
 
+  describe "getNodesInfo" $ do
+     it "fetches the responding node when LocalNode is used" $ withTestEnv $ do
+       res <- getNodesInfo LocalNode
+       liftIO $ case res of
+         -- This is really just a smoke test for response
+         -- parsing. Node info is so variable, there's not much I can
+         -- assert here.
+         Right NodesInfo {..} -> length nodesInfo `shouldBe` 1
+           --TODO: more assertions if possible
+         Left e -> expectationFailure ("Expected NodesInfo but got " <> show e)
+
   describe "Enum DocVersion" $ do
     it "follows the laws of Enum, Bounded" $ do
       evaluate (succ maxBound :: DocVersion) `shouldThrow` anyErrorCall


### PR DESCRIPTION
Worth noting that this does constitute a very minor breaking version change because I've changed 2 types in the status API to unify with values exposed by this new API (version and build). The good news is we're now using a proper version type, the one that cabal uses, so if the user needs to do semantic comparisons that is much easier. I was able to drop out some version sniffing code from the test suite to support this.

One small hitch is that I had to just export a plain `Object` for the node settings value. From what I can tell (and as the comment reads), this data is totally variable, keys will sometimes be there, sometimes not, and some are particular to the plugins installed.

We'll see how well my types hold up to the test suite, I tested on 1.7.