### PR TITLE
Added the OverloadedStrings extension to first example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Index Operations
 -- the multi-line examples into your ghci REPL.
 
 :set -XDeriveGeneric
+:set -XOverloadedStrings
 :{
 import Control.Applicative
 import Database.Bloodhound


### PR DESCRIPTION
The first example doesn't work without the OverloadedStrings extension. The Server keeps demanding it's argument to be of the type Text