### PR TITLE
Add support for cardinality aggregations

### DIFF
--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -1244,6 +1244,17 @@ main = hspec $ do
       searchExpectAggs search
       searchValidBucketAgg search "users" toTerms
 
+    it "returns cardinality aggregation results" $ withTestEnv $ do
+      _ <- insertData
+      let cardinality = CardinalityAgg $ mkCardinalityAggregation $ FieldName "user"
+      let search = mkAggregateSearch Nothing $ mkAggregations "users" cardinality
+      let search' = search { Database.Bloodhound.from = From 0, size = Size 0 }
+      searchExpectAggs search'
+      let docCountPair k n = (k, object ["value" .= Number n])
+      res <- searchTweets search'
+      liftIO $
+        fmap aggregations res `shouldBe` Right (Just (M.fromList [ docCountPair "users" 1]))
+
     it "can give collection hint parameters to term aggregations" $ when' (atleast es13) $ withTestEnv $ do
       _ <- insertData
       let terms = TermsAgg $ (mkTermsAggregation "user") { termCollectMode = Just BreadthFirst }


### PR DESCRIPTION
This pull request adds support for the Query side of cardinality aggregations.  The metric agg results are still unparsed

[ES Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-aggregations-metrics-cardinality-aggregation.html)