### PR TITLE
Beginnings of ES2 support - status page and error handling

### DIFF
--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -2990,7 +2990,7 @@ instance FromJSON MatchQueryType where
 instance FromJSON Status where
   parseJSON (Object v) = Status <$>
                          v .:? "ok" <*>
-                         v .: "status" <*>
+                         (v .:? "status" .!= 200) <*>
                          v .: "name" <*>
                          v .: "version" <*>
                          v .: "tagline"

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -3261,7 +3261,7 @@ instance (FromJSON a) => FromJSON (EsResultFound a) where
 instance FromJSON EsError where
   parseJSON (Object v) = EsError <$>
                          v .: "status" <*>
-                         v .: "error"
+                         (v .: "error" <|> (v .: "error" >>= (.: "reason")))
   parseJSON _ = empty
 
 instance FromJSON IndexAliasesSummary where


### PR DESCRIPTION
So i'm going to break all the rules and have 2 different things in this pull request.

This pull request is the start of getting unit tests passing against the latest 2.3 elasticsearch, while not removing support for the current set.

First difference is that the status response no longer contains a status value.[1]  Which i'm just defaulting to 200.

Second is that the error format has changed.  I have attempted to maintain API compatibility and therefore not exposed the full information which is available in the response.  You can see a couple of examples of errors at [2] and [3].  I am using the 'reason' property as hopefully it is more user friendly in explaining the actual issue.   There does seem value in changing the API to support all of the information contained response.  What is your opinion on this?

[1]

```
{
  "name" : "Jessica Jones",
  "cluster_name" : "elasticsearch",
  "version" : {
    "number" : "2.3.5",
    "build_hash" : "90f439ff60a3c0f497f91663701e64ccd01edbb4",
    "build_timestamp" : "2016-07-27T10:36:52Z",
    "build_snapshot" : false,
    "lucene_version" : "5.5.0"
  },
  "tagline" : "You Know, for Search"
}
```

[2]
```
{
   "error": {
      "root_cause": [
         {
            "type": "index_not_found_exception",
            "reason": "no such index",
            "resource.type": "index_expression",
            "resource.id": "something_doesnt_exist",
            "index": "something_doesnt_exist"
         }
      ],
      "type": "index_not_found_exception",
      "reason": "no such index",
      "resource.type": "index_expression",
      "resource.id": "something_doesnt_exist",
      "index": "something_doesnt_exist"
   },
   "status": 404
}
```

[3]
```
{
   "error": {
      "root_cause": [
         {
            "type": "query_parsing_exception",
            "reason": "Failed to parse",
            "index": "bloodhound-tests-twitter-1"
         }
      ],
      "type": "search_phase_execution_exception",
      "reason": "all shards failed",
      "phase": "query_fetch",
      "grouped": true,
      "failed_shards": [
         {
            "shard": 0,
            "index": "bloodhound-tests-twitter-1",
            "node": "7hzOFqh2TSW9gKMhtG4QYg",
            "reason": {
               "type": "query_parsing_exception",
               "reason": "Failed to parse",
               "index": "bloodhound-tests-twitter-1",
               "caused_by": {
                  "type": "json_parse_exception",
                  "reason": "Unrecognized token 'ds': was expecting ('true', 'false' or 'null')\n at [Source: [B@3123fbd8; line: 3, column: 27]"
               }
            }
         }
      ]
   },
   "status": 400
}
```