### PR TITLE
Fix parent child tests for 2.0.

### DIFF
--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -174,15 +174,32 @@ data ParentMapping = ParentMapping deriving (Eq, Show)
 
 instance ToJSON ParentMapping where
   toJSON ParentMapping =
-    object ["parent" .= Null ]
+    object ["parent" .=
+              object ["properties" .=
+                object [ "user"     .= object ["type"    .= ("string" :: Text)]
+                      -- Serializing the date as a date is breaking other tests, mysteriously.
+                      -- , "postDate" .= object [ "type"   .= ("date" :: Text)
+                      --                        , "format" .= ("YYYY-MM-dd`T`HH:mm:ss.SSSZZ" :: Text)]
+                      , "message"  .= object ["type" .= ("string" :: Text)]
+                      , "age"      .= object ["type" .= ("integer" :: Text)]
+                      , "location" .= object ["type" .= ("geo_point" :: Text)]
+                      ]]]
 
 data ChildMapping = ChildMapping deriving (Eq, Show)
 
 instance ToJSON ChildMapping where
   toJSON ChildMapping =
     object ["child" .=
-      object ["_parent" .= object ["type" .= ("parent" :: Text)]]
-    ]
+      object ["_parent" .= object ["type" .= ("parent" :: Text)]
+             , "properties" .=
+                  object [ "user"     .= object ["type"    .= ("string" :: Text)]
+                    -- Serializing the date as a date is breaking other tests, mysteriously.
+                    -- , "postDate" .= object [ "type"   .= ("date" :: Text)
+                    --                        , "format" .= ("YYYY-MM-dd`T`HH:mm:ss.SSSZZ" :: Text)]
+                    , "message"  .= object ["type" .= ("string" :: Text)]
+                    , "age"      .= object ["type" .= ("integer" :: Text)]
+                    , "location" .= object ["type" .= ("geo_point" :: Text)]
+                    ]]]
 
 data TweetMapping = TweetMapping deriving (Eq, Show)
 
@@ -924,8 +941,8 @@ main = hspec $ do
 
     it "indexes two documents in a parent/child relationship and checks that the child exists" $ withTestEnv $ do
       resetIndex
-      _ <- putMapping testIndex (MappingName "parent") ParentMapping
       _ <- putMapping testIndex (MappingName "child") ChildMapping
+      _ <- putMapping testIndex (MappingName "parent") ParentMapping
       _ <- indexDocument testIndex (MappingName "parent") defaultIndexDocumentSettings exampleTweet (DocId "1")
       let parent = (Just . DocumentParent . DocId) "1"
           ids = IndexDocumentSettings NoVersionControl parent


### PR DESCRIPTION
So it seems that to create parent child mappings in 2+ you must first create the child mapping AND then the parent.

Also 2+ has made indexes more strict.

If an index has multiple types which have matching properties then the types of those properties must be the same.

So in this example both the TweetMapping and ParentMapping must have the same types for the user, message, age, etc properties

maybe better explained by https://www.elastic.co/guide/en/elasticsearch/reference/2.0/breaking_20_mapping_changes.html#_conflicting_field_mappings