### PR TITLE
Format date as dd-MM-yyyy to support stricter 2.0+

### DIFF
--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -1917,10 +1917,7 @@ instance ToJSON DateRangeAggRange where
 instance ToJSON DateMathExpr where
   toJSON (DateMathExpr a mods) = String (fmtA a <> mconcat (fmtMod <$> mods))
     where fmtA DMNow = "now"
-          fmtA (DMDate date) = case toGregorian date of
-                                 (y,m,d) -> showText y <> "-" <>
-                                            showText m <> "-" <>
-                                            showText d <> "||"
+          fmtA (DMDate date) = (T.pack $ showGregorian date) <> "||"
           fmtMod (AddTime n u) = "+" <> showText n <> fmtU u
           fmtMod (SubtractTime n u) = "-" <> showText n <> fmtU u
           fmtMod (RoundDownTo u) = "/" <> fmtU u


### PR DESCRIPTION
So this lets an additional test pass on ES 2.0 due to stricter date parsing ( no more than that sadly )

It changes the date formatting to have leading 0's e.g.  02-02-2002.

It also removes more code than it adds :)