### PR TITLE
Wrap VersionNumber and LoadAvgs in Maybe #138

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -1,5 +1,5 @@
 name:                bloodhound
-version:             0.11.1.0
+version:             0.12.0.0
 synopsis:            ElasticSearch client library for Haskell
 description:         ElasticSearch made awesome for Haskell hackers
 homepage:            https://github.com/bitemyapp/bloodhound

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+0.12.0.0
+===================
+* #138 Make `nodeOSLoad` record a `Maybe` for Windows compatibility 
+* #138 Change the `nodePluginVersion` record to deal with plugins which report `NA` as their version.
+
 0.11.0.0
 ===================
 

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -4064,7 +4064,7 @@ data NodeOSStats = NodeOSStats {
     , nodeOSCPUIdle        :: Int
     , nodeOSCPUUser        :: Int
     , nodeOSCPUSys         :: Int
-    , nodeOSLoad           :: LoadAvgs
+    , nodeOSLoad           :: Maybe LoadAvgs
     , nodeOSUptime         :: NominalDiffTime
     , nodeOSTimestamp      :: UTCTime
     } deriving (Eq, Show, Generic, Typeable)
@@ -4189,7 +4189,7 @@ data NodePluginInfo = NodePluginInfo {
     , nodePluginJVM         :: Bool
     -- ^ Is this plugin running on the JVM
     , nodePluginDescription :: Text
-    , nodePluginVersion     :: VersionNumber
+    , nodePluginVersion     :: Maybe VersionNumber
     , nodePluginName        :: PluginName
     } deriving (Eq, Show, Generic, Typeable)
 
@@ -4875,7 +4875,7 @@ instance FromJSON NodeOSStats where
         swap <- o .: "swap"
         mem <- o .: "mem"
         cpu <- o .: "cpu"
-        load <- o .: "load_average"
+        load <- (Just <$> o .: "load_average" <|> pure Nothing)
         NodeOSStats <$> swap .: "free_in_bytes"
                     <*> swap .: "used_in_bytes"
                     <*> mem .: "actual_used_in_bytes"
@@ -5044,11 +5044,11 @@ parseNodeInfo nid o =
 instance FromJSON NodePluginInfo where
   parseJSON = withObject "NodePluginInfo" parse
     where
-      parse o = NodePluginInfo <$> o .: "site"
-                               <*> o .: "jvm"
-                               <*> o .: "description"
-                               <*> o .: "version"
-                               <*> o .: "name"
+      parse o = NodePluginInfo <$> o .:  "site"
+                               <*> o .:  "jvm"
+                               <*> o .:  "description"
+                               <*> (Just <$> (o .: "version") <|> pure Nothing)
+                               <*> o .:  "name"
 
 instance FromJSON NodeHTTPInfo where
   parseJSON = withObject "NodeHTTPInfo" parse


### PR DESCRIPTION
The version number issue is OS-agnostic, the LoadAvgs issue is Windows-specific. 

The latter could have been dealt with using a CPP, but I generally try to avoid that. 

This is a breaking change, but it's recent stuff, so I didn't know what you wanted me to do with the version numbers. (Also, I had to make other changes there for windows, which I'm going to keep separate until my 2.4 work pushes forward). 