### PR TITLE
Fix an example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 cabal.sandbox.config
 .cabal-sandbox/
 dist/
+dist-newstyle/
 .project
 .dist-buildwrapper/
 .DS_Store
+TAGS
 *.hi
 *.o
 bloodhound-*-docs/

--- a/README.md
+++ b/README.md
@@ -181,10 +181,9 @@ data TweetMapping = TweetMapping deriving (Eq, Show)
 :{
 instance ToJSON TweetMapping where
   toJSON TweetMapping =
-    object ["tweet" .=
-      object ["properties" .=
-        object ["location" .=
-          object ["type" .= ("geo_point" :: Text)]]]]
+    object ["properties" .=
+      object ["location" .=
+        object ["type" .= ("geo_point" :: Text)]]]
 :}
 
 resp <- withBH' $ putMapping testIndex testMapping TweetMapping

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -140,10 +140,9 @@ import           Database.Bloodhound.Types
 -- >>> :{
 --instance ToJSON TweetMapping where
 --          toJSON TweetMapping =
---            object ["tweet" .=
---              object ["properties" .=
---                object ["location" .=
---                  object ["type" .= ("geo_point" :: Text)]]]]
+--            object ["properties" .=
+--              object ["location" .=
+--                object ["type" .= ("geo_point" :: Text)]]]
 --data Location = Location { lat :: Double
 --                         , lon :: Double } deriving (Eq, Generic, Show)
 --data Tweet = Tweet { user     :: Text

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -620,8 +620,10 @@ instance Arbitrary Day where
     arbitrary = ModifiedJulianDay <$> (2000 +) <$> arbitrary
     shrink    = (ModifiedJulianDay <$>) . shrink . toModifiedJulianDay
 
+#if !MIN_VERSION_QuickCheck(2,9,0)
 instance Arbitrary a => Arbitrary (NonEmpty a) where
   arbitrary = liftA2 (:|) arbitrary arbitrary
+#endif
 
 arbitraryScore :: Gen Score
 arbitraryScore = fmap getPositive <$> arbitrary

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -177,47 +177,44 @@ data ParentMapping = ParentMapping deriving (Eq, Show)
 
 instance ToJSON ParentMapping where
   toJSON ParentMapping =
-    object ["parent" .=
-              object ["properties" .=
-                object [ "user"     .= object ["type"    .= ("string" :: Text)]
-                      -- Serializing the date as a date is breaking other tests, mysteriously.
-                      -- , "postDate" .= object [ "type"   .= ("date" :: Text)
-                      --                        , "format" .= ("YYYY-MM-dd`T`HH:mm:ss.SSSZZ" :: Text)]
-                      , "message"  .= object ["type" .= ("string" :: Text)]
-                      , "age"      .= object ["type" .= ("integer" :: Text)]
-                      , "location" .= object ["type" .= ("geo_point" :: Text)]
-                      ]]]
+    object ["properties" .=
+      object [ "user"     .= object ["type"    .= ("string" :: Text)]
+            -- Serializing the date as a date is breaking other tests, mysteriously.
+            -- , "postDate" .= object [ "type"   .= ("date" :: Text)
+            --                        , "format" .= ("YYYY-MM-dd`T`HH:mm:ss.SSSZZ" :: Text)]
+            , "message"  .= object ["type" .= ("string" :: Text)]
+            , "age"      .= object ["type" .= ("integer" :: Text)]
+            , "location" .= object ["type" .= ("geo_point" :: Text)]
+            ]]
 
 data ChildMapping = ChildMapping deriving (Eq, Show)
 
 instance ToJSON ChildMapping where
   toJSON ChildMapping =
-    object ["child" .=
-      object ["_parent" .= object ["type" .= ("parent" :: Text)]
-             , "properties" .=
-                  object [ "user"     .= object ["type"    .= ("string" :: Text)]
-                    -- Serializing the date as a date is breaking other tests, mysteriously.
-                    -- , "postDate" .= object [ "type"   .= ("date" :: Text)
-                    --                        , "format" .= ("YYYY-MM-dd`T`HH:mm:ss.SSSZZ" :: Text)]
-                    , "message"  .= object ["type" .= ("string" :: Text)]
-                    , "age"      .= object ["type" .= ("integer" :: Text)]
-                    , "location" .= object ["type" .= ("geo_point" :: Text)]
-                    ]]]
+    object ["_parent" .= object ["type" .= ("parent" :: Text)]
+           , "properties" .=
+                object [ "user"     .= object ["type"    .= ("string" :: Text)]
+                  -- Serializing the date as a date is breaking other tests, mysteriously.
+                  -- , "postDate" .= object [ "type"   .= ("date" :: Text)
+                  --                        , "format" .= ("YYYY-MM-dd`T`HH:mm:ss.SSSZZ" :: Text)]
+                  , "message"  .= object ["type" .= ("string" :: Text)]
+                  , "age"      .= object ["type" .= ("integer" :: Text)]
+                  , "location" .= object ["type" .= ("geo_point" :: Text)]
+                  ]]
 
 data TweetMapping = TweetMapping deriving (Eq, Show)
 
 instance ToJSON TweetMapping where
   toJSON TweetMapping =
-    object ["tweet" .=
-      object ["properties" .=
-        object [ "user"     .= object ["type"    .= ("string" :: Text)]
-               -- Serializing the date as a date is breaking other tests, mysteriously.
-               -- , "postDate" .= object [ "type"   .= ("date" :: Text)
-               --                        , "format" .= ("YYYY-MM-dd`T`HH:mm:ss.SSSZZ" :: Text)]
-               , "message"  .= object ["type" .= ("string" :: Text)]
-               , "age"      .= object ["type" .= ("integer" :: Text)]
-               , "location" .= object ["type" .= ("geo_point" :: Text)]
-               ]]]
+    object ["properties" .=
+      object [ "user"     .= object ["type"    .= ("string" :: Text)]
+             -- Serializing the date as a date is breaking other tests, mysteriously.
+             -- , "postDate" .= object [ "type"   .= ("date" :: Text)
+             --                        , "format" .= ("YYYY-MM-dd`T`HH:mm:ss.SSSZZ" :: Text)]
+             , "message"  .= object ["type" .= ("string" :: Text)]
+             , "age"      .= object ["type" .= ("integer" :: Text)]
+             , "location" .= object ["type" .= ("geo_point" :: Text)]
+             ]]
 
 exampleTweet :: Tweet
 exampleTweet = Tweet { user     = "bitemyapp"


### PR DESCRIPTION
No need to specify the mapping name twice, since `putMapping` does `PUT /$INDEXNAME/_mappings/$MAPPINGNAME` and you give it an `IndexName` and a `MappingName`. In fact, specifying the mapping name here breaks upsert semantics (you get `Root type mapping not empty after parsing!` exception when trying to add the same mapping twice).