### PR TITLE
Precise return type for the `bulk` operation

### DIFF
--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -613,8 +613,8 @@ parseEsResponse reply
         tryParseError = case eitherDecode body of
                           Right e -> return (Left e)
                           -- this case should not be possible
-                          Left _ -> explode
-        explode = throwM (EsProtocolException body)
+                          Left errdesc -> explode errdesc
+        explode rr = throwM (EsProtocolException body rr)
 
 -- | 'indexExists' enables you to check if an index exists. Returns 'Bool'
 --   in IO
@@ -672,7 +672,7 @@ listIndices =
                         keyedRows = [ HM.fromList (zip ks (T.words row)) | row <- rows ]
                         names = catMaybes (HM.lookup "index" <$> keyedRows)
                     in return (IndexName <$> names)
-      [] -> throwM (EsProtocolException body)
+      [] -> throwM (EsProtocolException body "Could not find any index")
 
 -- | 'updateIndexAliases' updates the server's index alias
 -- table. Operations are atomic. Explained in further detail at
@@ -827,10 +827,15 @@ deleteDocument (IndexName indexName)
 -- >>> let stream = V.fromList [BulkIndex testIndex testMapping (DocId "2") (toJSON (BulkTest "blah"))]
 -- >>> _ <- runBH' $ bulk stream
 -- >>> _ <- runBH' $ refreshIndex testIndex
-bulk :: MonadBH m => V.Vector BulkOperation -> m Reply
-bulk bulkOps = bindM2 post url (return body)
+bulk :: (MonadThrow m, MonadBH m) => V.Vector BulkOperation -> m BulkResponse
+bulk bulkOps = bindM2 post url (return body) >>= parseResponse
   where url = joinPath ["_bulk"]
         body = Just $ encodeBulkOperations bulkOps
+        parseResponse r = case eitherDecode respBody of
+                              Right a -> return a
+                              Left rr -> explode rr
+            where respBody = responseBody r
+                  explode rr = throwM (EsProtocolException respBody rr)
 
 -- | 'encodeBulkOperations' is a convenience function for dumping a vector of 'BulkOperation'
 --   into an 'L.ByteString'

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -55,7 +55,7 @@ import           Test.QuickCheck
 
 
 testServer  :: Server
-testServer  = Server "http://localhost:9200"
+testServer  = Server "http://192.168.56.102:9200"
 testIndex   :: IndexName
 testIndex   = IndexName "bloodhound-tests-twitter-1"
 testMapping :: MappingName
@@ -905,6 +905,60 @@ main = hspec $ do
       liftIO $ do
         validateStatus resp 200
         validateStatus deleteResp 200
+
+  describe "bulk API" $ do
+    let tweets = [ (DocId "testtweet1", tweetWithExtra), (DocId "testtweet2", exampleTweet) ]
+        docids = map fst tweets
+        _type = MappingName "tweet"
+    it "bulk creates documents" $ withTestEnv $ do
+      resetIndex
+      resp@(BulkResponse _ errors items) <- bulk $ V.fromList [ BulkCreate testIndex _type docid (toJSON tweet) | (docid, tweet) <- tweets ]
+      liftIO $ do
+        when errors (expectationFailure ("Error when bulk-creating tweets: " <> show resp))
+        docids' <- forM items $ \(BulkResponseItem resptype (BulkItemResult idx rtype docid res)) -> do
+          unless (resptype == OperationCreate) (expectationFailure ("Invalid operation type: " <> show resp))
+          idx `shouldBe` testIndex
+          rtype `shouldBe` _type
+          case res of
+              Left rr -> expectationFailure ("Invalid item result for docid " <> show docid <> ": " <> show rr)
+              Right _ -> return ()
+          return docid
+        docids' `shouldMatchList` docids
+    it "bulk updates documents" $ withTestEnv $ do
+      let docid = fst (head tweets)
+      resp@(BulkResponse _ errors items) <- bulk $ V.fromList [ BulkUpdate testIndex _type docid (toJSON exampleTweet) ]
+      liftIO $ do
+        when errors (expectationFailure ("Error when bulk-updating tweets: " <> show resp))
+        case items of
+            [BulkResponseItem OperationUpdate (BulkItemResult idx rtype docid' res)] -> do
+              idx `shouldBe` testIndex
+              rtype `shouldBe` _type
+              docid' `shouldBe` docid
+              case res of
+                  Left rr -> expectationFailure ("Invalid item result for docid " <> show docid' <> ": " <> show rr)
+                  Right _ -> return ()
+            _ -> expectationFailure ("Invalid response: " <> show resp)
+    it "fails when creating a document with an existing docid" $ withTestEnv $ do
+      let docid = fst (head tweets)
+      resp@(BulkResponse _ errors items) <- bulk $ V.fromList [ BulkCreate testIndex _type docid (toJSON exampleTweet) ]
+      liftIO $ do
+        unless errors (expectationFailure ("This test should have failed: " <> show resp))
+        case items of
+            [BulkResponseItem OperationCreate (BulkItemResult _ _ _ res)] ->
+              case res of
+                  Left  _ -> return ()
+                  Right _ -> expectationFailure ("This item should have failed: " <> show resp)
+            _ -> expectationFailure ("Invalid response: " <> show resp)
+    it "bulk indexes documents" $ withTestEnv $ do
+      resp@(BulkResponse _ errors items) <- bulk $ V.fromList [ BulkIndex testIndex _type docid (toJSON tweet) | (docid, tweet) <- tweets ]
+      liftIO $ do
+        when errors (expectationFailure ("Error when bulk-indexing tweets: " <> show resp))
+        mapM_ ( (`shouldBe` OperationIndex) . bulkResponseItemType ) items
+    it "bulk deletes documents" $ withTestEnv $ do
+      resp@(BulkResponse _ errors items) <- bulk $ V.fromList [ BulkDelete testIndex _type docid | (docid, _) <- tweets ]
+      liftIO $ do
+        when errors (expectationFailure ("Error when bulk-deleting tweets: " <> show resp))
+        mapM_ ( (`shouldBe` OperationDelete) . bulkResponseItemType ) items
 
   describe "error parsing"  $ do
     it "can parse EsErrors for < 2.0" $ when' (atmost es16) $ withTestEnv $ do
@@ -1816,3 +1870,4 @@ main = hspec $ do
     propJSON (Proxy :: Proxy InitialShardCount)
     propJSON (Proxy :: Proxy FSType)
     propJSON (Proxy :: Proxy CompoundFormat)
+


### PR DESCRIPTION
This patches introduces the following changes :
- Add a description field to the `EsProtocolException` constructor. That was useful when checking the aeson code, and I think it would be useful when users report errors if the ES server protocol changes. This might be part of a distinct patch/PR though.
- Several new types related to bulk operations responses are introduced.
- The `bulk` function has been altered. It now throws an `EsProtocolException` when the json can't be decoded.
- A few tests have been added that should exercise the json content.

It works for me (tm), but naming could definitely be improved. I will be away for a few days, but should be able to integrate all remarks by the end of next week.
