### PR TITLE
Drop doctest-prop

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -92,7 +92,6 @@ test-suite doctests
                       bloodhound,
                       directory,
                       doctest >= 0.10.1,
-                      doctest-prop,
                       filepath
   else
     buildable: False

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -126,7 +126,6 @@ import           Database.Bloodhound.Types
 -- >>> :set -XOverloadedStrings
 -- >>> :set -XDeriveGeneric
 -- >>> import Database.Bloodhound
--- >>> import Test.DocTest.Prop (assert)
 -- >>> let testServer = (Server "http://localhost:9200")
 -- >>> let runBH' = withBH defaultManagerSettings testServer
 -- >>> let testIndex = IndexName "twitter"

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -8,7 +8,6 @@ extra-deps:
 - http-types-0.9
 - attoparsec-0.13.0.1
 - doctest-0.10.1
-- doctest-prop-0.2.0.1
 - quickcheck-properties-0.1
 - semigroups-0.18.0.1
 - uri-bytestring-0.1.9

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -10,7 +10,6 @@ extra-deps:
 - http-client-0.5.0
 - attoparsec-0.13.0.1
 - doctest-0.10.1
-- doctest-prop-0.2.0.1
 - quickcheck-properties-0.1
 - semigroups-0.18.0.1
 - tagged-0.8.3

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -2,7 +2,6 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- doctest-prop-0.2.0.1
 - quickcheck-properties-0.1
 
 # - http-client-0.5.0


### PR DESCRIPTION
AFAICT we weren't even using it anymore. We imported the function assert
and then never used it in the doctests.

This is for #146. We'll see what travis says.