### PR TITLE
Support for 'Suggesters' and 'Template Queries'

### DIFF
--- a/src/Database/V1/Bloodhound/Client.hs
+++ b/src/Database/V1/Bloodhound/Client.hs
@@ -861,17 +861,17 @@ scanSearch indexName mappingName search = do
 --   syntax if you want to add things like aggregations or highlights while still using
 --   this helper function.
 mkSearch :: Maybe Query -> Maybe Filter -> Search
-mkSearch query filter = Search query filter Nothing Nothing Nothing False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing
+mkSearch query filter = Search query filter Nothing Nothing Nothing False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing
 
 -- | 'mkAggregateSearch' is a helper function that defaults everything in a 'Search' except for
 --   the 'Query' and the 'Aggregation'.
 mkAggregateSearch :: Maybe Query -> Aggregations -> Search
-mkAggregateSearch query mkSearchAggs = Search query Nothing Nothing (Just mkSearchAggs) Nothing False (From 0) (Size 0) SearchTypeQueryThenFetch Nothing Nothing
+mkAggregateSearch query mkSearchAggs = Search query Nothing Nothing (Just mkSearchAggs) Nothing False (From 0) (Size 0) SearchTypeQueryThenFetch Nothing Nothing Nothing
 
 -- | 'mkHighlightSearch' is a helper function that defaults everything in a 'Search' except for
 --   the 'Query' and the 'Aggregation'.
 mkHighlightSearch :: Maybe Query -> Highlights -> Search
-mkHighlightSearch query searchHighlights = Search query Nothing Nothing Nothing (Just searchHighlights) False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing
+mkHighlightSearch query searchHighlights = Search query Nothing Nothing Nothing (Just searchHighlights) False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing
 
 -- | 'pageSearch' is a helper function that takes a search and assigns the from
 --    and size fields for the search. The from parameter defines the offset

--- a/src/Database/V1/Bloodhound/Types.hs
+++ b/src/Database/V1/Bloodhound/Types.hs
@@ -1103,7 +1103,7 @@ unpackId (DocId docId) = docId
 
 type TrackSortScores = Bool
 newtype From = From Int deriving (Eq, Read, Show, Generic, ToJSON)
-newtype Size = Size Int deriving (Eq, Read, Show, Generic, ToJSON, FromJSON)
+newtype Size = Size Int deriving (Eq, Read, Show, Generic, ToJSON, FromJSON, Typeable)
 
 data Search = Search { queryBody       :: Maybe Query
                      , filterBody      :: Maybe Filter
@@ -1654,7 +1654,7 @@ type TemplateQueryKey = Text
 type TemplateQueryValue = Text
 
 newtype TemplateQueryKeyValuePairs = TemplateQueryKeyValuePairs (HM.HashMap TemplateQueryKey TemplateQueryValue)
-  deriving (Eq, Read, Show, Generic)
+  deriving (Eq, Read, Show, Generic, Typeable)
 
 instance ToJSON TemplateQueryKeyValuePairs where
   toJSON (TemplateQueryKeyValuePairs x) = Object $ HM.map toJSON x
@@ -5340,7 +5340,7 @@ data Suggest = Suggest { suggestText :: Text
                        , suggestName :: Text
                        , suggestType :: SuggestType
                        }
- deriving (Show, Generic, Eq, Read)
+ deriving (Show, Generic, Eq, Read, Typeable)
 
 instance ToJSON Suggest where
   toJSON Suggest{..} = object [ "text" .= suggestText
@@ -5359,7 +5359,7 @@ instance FromJSON Suggest where
   parseJSON x = typeMismatch "Suggest" x
 
 data SuggestType = SuggestTypePhraseSuggester PhraseSuggester
-  deriving (Show, Generic, Eq, Read)
+  deriving (Show, Generic, Eq, Read, Typeable)
 
 instance ToJSON SuggestType where
   toJSON (SuggestTypePhraseSuggester x) = object ["phrase" .= x]
@@ -5383,7 +5383,7 @@ data PhraseSuggester =
                   , phraseSuggesterHighlight :: Maybe PhraseSuggesterHighlighter
                   , phraseSuggesterCollate :: Maybe PhraseSuggesterCollate
                   }
-  deriving (Show, Generic, Eq, Read)
+  deriving (Show, Generic, Eq, Read, Typeable)
 
 instance ToJSON PhraseSuggester where
   toJSON PhraseSuggester{..} = omitNulls [ "field" .= phraseSuggesterField
@@ -5423,7 +5423,7 @@ data PhraseSuggesterHighlighter =
   PhraseSuggesterHighlighter { phraseSuggesterHighlighterPreTag :: Text
                              , phraseSuggesterHighlighterPostTag :: Text
                              }
-  deriving (Show, Generic, Eq, Read)
+  deriving (Show, Generic, Eq, Read, Typeable)
 
 instance ToJSON PhraseSuggesterHighlighter where
   toJSON PhraseSuggesterHighlighter{..} =
@@ -5441,7 +5441,7 @@ data PhraseSuggesterCollate =
   PhraseSuggesterCollate { phraseSuggesterCollateTemplateQuery :: TemplateQueryInline
                          , phraseSuggesterCollatePrune :: Bool
                          }
-  deriving (Show, Generic, Eq, Read)
+  deriving (Show, Generic, Eq, Read, Typeable)
 
 instance ToJSON PhraseSuggesterCollate where
   toJSON PhraseSuggesterCollate{..} = object [ "query" .= object

--- a/src/Database/V1/Bloodhound/Types.hs
+++ b/src/Database/V1/Bloodhound/Types.hs
@@ -5460,6 +5460,9 @@ instance FromJSON PhraseSuggesterCollate where
     return $ PhraseSuggesterCollate (TemplateQueryInline inline' params') prune'
   parseJSON x = typeMismatch "PhraseSuggesterCollate" x
 
+mkPhraseSuggesterCollate :: TemplateQueryInline -> PhraseSuggesterCollate
+mkPhraseSuggesterCollate tQuery = PhraseSuggesterCollate tQuery False
+
 data SuggestOptions =
   SuggestOptions { suggestOptionsText :: Text
                  , suggestOptionsScore :: Double

--- a/src/Database/V5/Bloodhound/Client.hs
+++ b/src/Database/V5/Bloodhound/Client.hs
@@ -1044,7 +1044,7 @@ scanSearch indexName mappingName search = do
 -- >>> mkSearch (Just query) Nothing
 -- Search {queryBody = Just (TermQuery (Term {termField = "user", termValue = "bitemyapp"}) Nothing), filterBody = Nothing, sortBody = Nothing, aggBody = Nothing, highlight = Nothing, trackSortScores = False, from = From 0, size = Size 10, searchType = SearchTypeQueryThenFetch, fields = Nothing, source = Nothing}
 mkSearch :: Maybe Query -> Maybe Filter -> Search
-mkSearch query filter = Search query filter Nothing Nothing Nothing False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing
+mkSearch query filter = Search query filter Nothing Nothing Nothing False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing
 
 -- | 'mkAggregateSearch' is a helper function that defaults everything in a 'Search' except for
 --   the 'Query' and the 'Aggregation'.
@@ -1054,7 +1054,7 @@ mkSearch query filter = Search query filter Nothing Nothing Nothing False (From 
 -- TermsAgg (TermsAggregation {term = Left "user", termInclude = Nothing, termExclude = Nothing, termOrder = Nothing, termMinDocCount = Nothing, termSize = Nothing, termShardSize = Nothing, termCollectMode = Just BreadthFirst, termExecutionHint = Nothing, termAggs = Nothing})
 -- >>> let myAggregation = mkAggregateSearch Nothing $ mkAggregations "users" terms
 mkAggregateSearch :: Maybe Query -> Aggregations -> Search
-mkAggregateSearch query mkSearchAggs = Search query Nothing Nothing (Just mkSearchAggs) Nothing False (From 0) (Size 0) SearchTypeQueryThenFetch Nothing Nothing
+mkAggregateSearch query mkSearchAggs = Search query Nothing Nothing (Just mkSearchAggs) Nothing False (From 0) (Size 0) SearchTypeQueryThenFetch Nothing Nothing Nothing
 
 -- | 'mkHighlightSearch' is a helper function that defaults everything in a 'Search' except for
 --   the 'Query' and the 'Aggregation'.
@@ -1063,7 +1063,7 @@ mkAggregateSearch query mkSearchAggs = Search query Nothing Nothing (Just mkSear
 -- >>> let testHighlight = Highlights Nothing [FieldHighlight (FieldName "message") Nothing]
 -- >>> let search = mkHighlightSearch (Just query) testHighlight
 mkHighlightSearch :: Maybe Query -> Highlights -> Search
-mkHighlightSearch query searchHighlights = Search query Nothing Nothing Nothing (Just searchHighlights) False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing
+mkHighlightSearch query searchHighlights = Search query Nothing Nothing Nothing (Just searchHighlights) False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing
 
 -- | 'pageSearch' is a helper function that takes a search and assigns the from
 --    and size fields for the search. The from parameter defines the offset

--- a/src/Database/V5/Bloodhound/Types.hs
+++ b/src/Database/V5/Bloodhound/Types.hs
@@ -2866,7 +2866,7 @@ instance ToJSON MultiMatchQuery where
                  , "query" .= query
                  , "operator" .= boolOp
                  , "zero_terms_query" .= ztQ
-                 , "tiebreaker" .= tb
+                 , "tie_breaker" .= tb
                  , "type" .= mmqt
                  , "cutoff_frequency" .= cf
                  , "analyzer" .= analyzer
@@ -2881,7 +2881,7 @@ instance FromJSON MultiMatchQuery where
                            <*> o .: "query"
                            <*> o .: "operator"
                            <*> o .: "zero_terms_query"
-                           <*> o .:? "tiebreaker"
+                           <*> o .:? "tie_breaker"
                            <*> o .:? "type"
                            <*> o .:? "cutoff_frequency"
                            <*> o .:? "analyzer"

--- a/src/Database/V5/Bloodhound/Types.hs
+++ b/src/Database/V5/Bloodhound/Types.hs
@@ -5238,6 +5238,9 @@ instance FromJSON PhraseSuggesterCollate where
     return $ PhraseSuggesterCollate (TemplateQueryInline inline' params') prune'
   parseJSON x = typeMismatch "PhraseSuggesterCollate" x
 
+mkPhraseSuggesterCollate :: TemplateQueryInline -> PhraseSuggesterCollate
+mkPhraseSuggesterCollate tQuery = PhraseSuggesterCollate tQuery False
+
 data SuggestOptions =
   SuggestOptions { suggestOptionsText :: Text
                  , suggestOptionsScore :: Double

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -18,4 +18,5 @@ extra-deps:
 - uri-bytestring-0.1.9
 - void-0.7.1
 - generics-sop-0.2.2.0
+- unordered-containers-0.2.6.0
 resolver: lts-2.18

--- a/tests/V1/tests.hs
+++ b/tests/V1/tests.hs
@@ -1112,6 +1112,17 @@ main = hspec $ do
       liftIO $
         myTweet `shouldBe` Right exampleTweet
 
+    it "returns document for multi-match query with a custom tiebreaker" $ withTestEnv $ do
+      _ <- insertData
+      let tiebreaker = Just $ Tiebreaker 0.3
+          flds = [FieldName "user", FieldName "message"]
+          multiQuery' = mkMultiMatchQuery flds (QueryString "bitemyapp")
+          query =  QueryMultiMatchQuery $ multiQuery' { multiMatchQueryTiebreaker = tiebreaker }
+          search = mkSearch (Just query) Nothing
+      myTweet <- searchTweet search
+      liftIO $
+        myTweet `shouldBe` Right exampleTweet
+
     it "returns document for bool query" $ withTestEnv $ do
       _ <- insertData
       let innerQuery = QueryMatchQuery $

--- a/tests/V5/tests.hs
+++ b/tests/V5/tests.hs
@@ -610,6 +610,12 @@ instance ApproxEq BuildHash
 instance ApproxEq TemplateQueryKeyValuePairs where
   (=~) = (==)
 instance ApproxEq TemplateQueryInline
+instance ApproxEq Size
+instance ApproxEq PhraseSuggesterHighlighter
+instance ApproxEq PhraseSuggesterCollate
+instance ApproxEq PhraseSuggester
+instance ApproxEq SuggestType
+instance ApproxEq Suggest
 
 -- | Due to the way nodeattrfilters get serialized here, they may come
 -- out in a different order, but they are morally equivalent
@@ -907,6 +913,12 @@ instance Arbitrary CompoundFormat where arbitrary = sopArbitrary; shrink = gener
 instance Arbitrary FsSnapshotRepo where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary SnapshotRepoName where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary TemplateQueryInline where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary PhraseSuggesterCollate where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary PhraseSuggesterHighlighter where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary Size where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary PhraseSuggester where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary SuggestType where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary Suggest where arbitrary = sopArbitrary; shrink = genericShrink
 
 newtype UpdatableIndexSetting' = UpdatableIndexSetting' UpdatableIndexSetting
                                deriving (Show, Eq, ToJSON, FromJSON, ApproxEq, Typeable)
@@ -1673,6 +1685,7 @@ main = hspec $ do
     propJSON (Proxy :: Proxy FSType)
     propJSON (Proxy :: Proxy CompoundFormat)
     propJSON (Proxy :: Proxy TemplateQueryInline)
+    propJSON (Proxy :: Proxy Suggest)
 
 -- Temporary solution for lacking of generic derivation of Arbitrary
 -- We use generics-sop, as it's much more concise than directly using GHC.Generics

--- a/tests/V5/tests.hs
+++ b/tests/V5/tests.hs
@@ -1087,6 +1087,17 @@ main = hspec $ do
       liftIO $
         myTweet `shouldBe` Right exampleTweet
 
+    it "returns document for multi-match query with a custom tiebreaker" $ withTestEnv $ do
+      _ <- insertData
+      let tiebreaker = Just $ Tiebreaker 0.3
+          flds = [FieldName "user", FieldName "message"]
+          multiQuery' = mkMultiMatchQuery flds (QueryString "bitemyapp")
+          query =  QueryMultiMatchQuery $ multiQuery' { multiMatchQueryTiebreaker = tiebreaker }
+          search = mkSearch (Just query) Nothing
+      myTweet <- searchTweet search
+      liftIO $
+        myTweet `shouldBe` Right exampleTweet
+
     it "returns document for bool query" $ withTestEnv $ do
       _ <- insertData
       let innerQuery = QueryMatchQuery $

--- a/tests/V5/tests.hs
+++ b/tests/V5/tests.hs
@@ -607,6 +607,9 @@ instance (ApproxEq l, Show l, ApproxEq r, Show r) => ApproxEq (Either l r) where
 instance ApproxEq NodeAttrFilter
 instance ApproxEq NodeAttrName
 instance ApproxEq BuildHash
+instance ApproxEq TemplateQueryKeyValuePairs where
+  (=~) = (==)
+instance ApproxEq TemplateQueryInline
 
 -- | Due to the way nodeattrfilters get serialized here, they may come
 -- out in a different order, but they are morally equivalent
@@ -756,6 +759,7 @@ instance Arbitrary Query where
                                  , QuerySimpleQueryStringQuery <$> arbitrary
                                  , QueryRangeQuery <$> arbitrary
                                  , QueryRegexpQuery <$> arbitrary
+                                 , QueryTemplateQueryInline <$> arbitrary
                                  ]
   shrink = genericShrink
 
@@ -790,6 +794,10 @@ instance Arbitrary VersionNumber where
   arbitrary = mk . fmap getPositive . getNonEmpty <$> arbitrary
     where
       mk versions = VersionNumber (Vers.Version versions [])
+
+instance Arbitrary TemplateQueryKeyValuePairs where
+  arbitrary = TemplateQueryKeyValuePairs . HM.fromList <$> arbitrary
+  shrink (TemplateQueryKeyValuePairs x) = map (TemplateQueryKeyValuePairs . HM.fromList) . shrink $ HM.toList x
 
 instance Arbitrary IndexName where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary MappingName where arbitrary = sopArbitrary; shrink = genericShrink
@@ -898,6 +906,7 @@ instance Arbitrary FSType where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary CompoundFormat where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary FsSnapshotRepo where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary SnapshotRepoName where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary TemplateQueryInline where arbitrary = sopArbitrary; shrink = genericShrink
 
 newtype UpdatableIndexSetting' = UpdatableIndexSetting' UpdatableIndexSetting
                                deriving (Show, Eq, ToJSON, FromJSON, ApproxEq, Typeable)
@@ -1098,6 +1107,21 @@ main = hspec $ do
       myTweet <- searchTweet search
       liftIO $
         myTweet `shouldBe` Right exampleTweet
+
+    it "returns document for for inline template query" $ withTestEnv $ do
+      _ <- insertData
+      let innerQuery = QueryMatchQuery $
+                         mkMatchQuery (FieldName "{{userKey}}")
+                                      (QueryString "{{bitemyappKey}}")
+          templateParams = TemplateQueryKeyValuePairs $ HM.fromList
+                            [ ("userKey", "user")
+                            , ("bitemyappKey", "bitemyapp")
+                            ]
+          templateQuery = QueryTemplateQueryInline $
+                            TemplateQueryInline innerQuery templateParams
+          search = mkSearch (Just templateQuery) Nothing
+      myTweet <- searchTweet search
+      liftIO $ myTweet `shouldBe` Right exampleTweet
 
 
   describe "sorting" $ do
@@ -1648,6 +1672,7 @@ main = hspec $ do
     propJSON (Proxy :: Proxy InitialShardCount)
     propJSON (Proxy :: Proxy FSType)
     propJSON (Proxy :: Proxy CompoundFormat)
+    propJSON (Proxy :: Proxy TemplateQueryInline)
 
 -- Temporary solution for lacking of generic derivation of Arbitrary
 -- We use generics-sop, as it's much more concise than directly using GHC.Generics


### PR DESCRIPTION
This PR adds two functionalities:
* Inline 'template queries', which can be passed to the "_search" endpoint [1]
* A framework for 'suggesters' [2], with support for the 'Phrase Suggester' [3].
* It also includes a test which was requested in #172

A few notes:
* Tests for the new types and functions are included, along with some helper functions.
* Currently, this we're limiting to one suggestion request per search, although elastic supports 'n'.


[1] https://www.elastic.co/guide/en/elasticsearch/reference/5.0/query-dsl-template-query.html
[2] https://www.elastic.co/guide/en/elasticsearch/reference/5.0/search-suggesters.htm
[3] https://www.elastic.co/guide/en/elasticsearch/reference/5.0/search-suggesters-phrase.html
