### PR TITLE
Fixup warnings about unused function and redundant constraints.

### DIFF
--- a/src/Database/V1/Bloodhound/Types.hs
+++ b/src/Database/V1/Bloodhound/Types.hs
@@ -5460,9 +5460,6 @@ instance FromJSON PhraseSuggesterCollate where
     return $ PhraseSuggesterCollate (TemplateQueryInline inline' params') prune'
   parseJSON x = typeMismatch "PhraseSuggesterCollate" x
 
-mkPhraseSuggesterCollate :: TemplateQueryInline -> PhraseSuggesterCollate
-mkPhraseSuggesterCollate tQuery = PhraseSuggesterCollate tQuery False
-
 data SuggestOptions =
   SuggestOptions { suggestOptionsText :: Text
                  , suggestOptionsScore :: Double

--- a/src/Database/V5/Bloodhound/Types.hs
+++ b/src/Database/V5/Bloodhound/Types.hs
@@ -2098,7 +2098,7 @@ instance BucketAggregation DateRangeResult where
   docCount = dateRangeDocCount
   aggs = dateRangeAggs
 
-instance (FromJSON a, BucketAggregation a) => FromJSON (Bucket a) where
+instance (FromJSON a) => FromJSON (Bucket a) where
   parseJSON (Object v) = Bucket <$>
                          v .: "buckets"
   parseJSON _ = mempty
@@ -5237,9 +5237,6 @@ instance FromJSON PhraseSuggesterCollate where
     prune' <- o .:? "prune" .!= False
     return $ PhraseSuggesterCollate (TemplateQueryInline inline' params') prune'
   parseJSON x = typeMismatch "PhraseSuggesterCollate" x
-
-mkPhraseSuggesterCollate :: TemplateQueryInline -> PhraseSuggesterCollate
-mkPhraseSuggesterCollate tQuery = PhraseSuggesterCollate tQuery False
 
 data SuggestOptions =
   SuggestOptions { suggestOptionsText :: Text


### PR DESCRIPTION
Compiling with GHC 8.0.1 and warnings as errors I had the following issues:
```haskell
[ 3 of 10] Compiling Database.V5.Bloodhound.Types ( src/Database/V5/Bloodhound/Types.hs, dist/build/Database/V5/Bloodhound/Types.o )

src/Database/V5/Bloodhound/Types.hs:2101:10: warning: [-Wredundant-constraints]
    • Redundant constraint: BucketAggregation a
    • In the instance declaration for ‘FromJSON (Bucket a)’

src/Database/V5/Bloodhound/Types.hs:5242:1: warning: [-Wunused-top-binds]
    Defined but not used: ‘mkPhraseSuggesterCollate’

```

This change is just fixing those issues for V5 and V1. I didn't really dig into the code too much so if I'm barking up the wrong tree please let me know.