### PR TITLE
Add support for script-like things (`function_score` and `script_fields`)

### DIFF
--- a/src/Database/V5/Bloodhound/Client.hs
+++ b/src/Database/V5/Bloodhound/Client.hs
@@ -1044,7 +1044,7 @@ scanSearch indexName mappingName search = do
 -- >>> mkSearch (Just query) Nothing
 -- Search {queryBody = Just (TermQuery (Term {termField = "user", termValue = "bitemyapp"}) Nothing), filterBody = Nothing, sortBody = Nothing, aggBody = Nothing, highlight = Nothing, trackSortScores = False, from = From 0, size = Size 10, searchType = SearchTypeQueryThenFetch, fields = Nothing, source = Nothing}
 mkSearch :: Maybe Query -> Maybe Filter -> Search
-mkSearch query filter = Search query filter Nothing Nothing Nothing False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing
+mkSearch query filter = Search query filter Nothing Nothing Nothing False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing Nothing
 
 -- | 'mkAggregateSearch' is a helper function that defaults everything in a 'Search' except for
 --   the 'Query' and the 'Aggregation'.
@@ -1054,7 +1054,7 @@ mkSearch query filter = Search query filter Nothing Nothing Nothing False (From 
 -- TermsAgg (TermsAggregation {term = Left "user", termInclude = Nothing, termExclude = Nothing, termOrder = Nothing, termMinDocCount = Nothing, termSize = Nothing, termShardSize = Nothing, termCollectMode = Just BreadthFirst, termExecutionHint = Nothing, termAggs = Nothing})
 -- >>> let myAggregation = mkAggregateSearch Nothing $ mkAggregations "users" terms
 mkAggregateSearch :: Maybe Query -> Aggregations -> Search
-mkAggregateSearch query mkSearchAggs = Search query Nothing Nothing (Just mkSearchAggs) Nothing False (From 0) (Size 0) SearchTypeQueryThenFetch Nothing Nothing Nothing
+mkAggregateSearch query mkSearchAggs = Search query Nothing Nothing (Just mkSearchAggs) Nothing False (From 0) (Size 0) SearchTypeQueryThenFetch Nothing Nothing Nothing Nothing
 
 -- | 'mkHighlightSearch' is a helper function that defaults everything in a 'Search' except for
 --   the 'Query' and the 'Aggregation'.
@@ -1063,7 +1063,7 @@ mkAggregateSearch query mkSearchAggs = Search query Nothing Nothing (Just mkSear
 -- >>> let testHighlight = Highlights Nothing [FieldHighlight (FieldName "message") Nothing]
 -- >>> let search = mkHighlightSearch (Just query) testHighlight
 mkHighlightSearch :: Maybe Query -> Highlights -> Search
-mkHighlightSearch query searchHighlights = Search query Nothing Nothing Nothing (Just searchHighlights) False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing
+mkHighlightSearch query searchHighlights = Search query Nothing Nothing Nothing (Just searchHighlights) False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing Nothing
 
 -- | 'pageSearch' is a helper function that takes a search and assigns the from
 --    and size fields for the search. The from parameter defines the offset

--- a/src/Database/V5/Bloodhound/Types.hs
+++ b/src/Database/V5/Bloodhound/Types.hs
@@ -180,6 +180,23 @@ module Database.V5.Bloodhound.Types
        , BoolQuery(..)
        , BoostingQuery(..)
        , CommonTermsQuery(..)
+       , FunctionScoreQuery(..)
+       , BoostMode(..)
+       , ScoreMode(..)
+       , FunctionScoreFunctions(..)
+       , ComponentFunctionScoreFunction(..)
+       , FunctionScoreFunction(..)
+       , FunctionScoreScript(..)
+       , FunctionScoreScriptInline(..)
+       , FunctionScoreScriptParams(..)
+       , FunctionScoreScriptParamName
+       , FunctionScoreScriptParamValue
+       , Weight(..)
+       , Seed(..)
+       , FieldValueFactor(..)
+       , Factor(..)
+       , FactorModifier(..)
+       , FactorMissingFieldValue(..)
        , DisMaxQuery(..)
        , FuzzyLikeThisQuery(..)
        , FuzzyLikeFieldQuery(..)
@@ -1206,6 +1223,7 @@ data Query =
   | QueryBoostingQuery          BoostingQuery
   | QueryCommonTermsQuery       CommonTermsQuery
   | ConstantScoreQuery          Query Boost
+  | QueryFunctionScoreQuery     FunctionScoreQuery
   | QueryDisMaxQuery            DisMaxQuery
   | QueryFuzzyLikeThisQuery     FuzzyLikeThisQuery
   | QueryFuzzyLikeFieldQuery    FuzzyLikeFieldQuery
@@ -1418,6 +1436,94 @@ data FuzzyLikeThisQuery =
   , fuzzyLikeBoost               :: Boost
   , fuzzyLikeAnalyzer            :: Maybe Analyzer
   } deriving (Eq, Read, Show, Generic, Typeable)
+
+data FunctionScoreQuery =
+  FunctionScoreQuery { functionScoreQuery     :: Maybe Query
+                     , functionScoreBoost     :: Maybe Boost
+                     , functionScoreFunctions :: FunctionScoreFunctions
+                     , functionScoreMaxBoost  :: Maybe Boost
+                     , functionScoreBoostMode :: Maybe BoostMode
+                     , functionScoreMinScore  :: Score
+                     , functionScoreScoreMode :: Maybe ScoreMode
+                     } deriving (Eq, Read, Show, Generic, Typeable)
+
+data BoostMode =
+  BoostModeMultiply
+  | BoostModeReplace
+  | BoostModeSum
+  | BoostModeAvg
+  | BoostModeMax
+  | BoostModeMin deriving (Eq, Read, Show, Generic, Typeable)
+
+data ScoreMode =
+  ScoreModeMultiply
+  | ScoreModeSum
+  | ScoreModeAvg
+  | ScoreModeFirst
+  | ScoreModeMax
+  | ScoreModeMin deriving (Eq, Read, Show, Generic, Typeable)
+
+data FunctionScoreFunctions =
+  FunctionScoreSingle FunctionScoreFunction
+  | FunctionScoreMultiple (NonEmpty ComponentFunctionScoreFunction) deriving (Eq, Read, Show, Generic, Typeable)
+
+data ComponentFunctionScoreFunction =
+  ComponentFunctionScoreFunction { componentScoreFunctionFilter :: Maybe Filter
+                                 , componentScoreFunction       :: FunctionScoreFunction
+                                 , componentScoreFunctionWeight :: Maybe Weight
+                                 } deriving (Eq, Read, Show, Generic, Typeable)
+
+data FunctionScoreFunction =
+  FunctionScoreFunctionScript FunctionScoreScript
+  | FunctionScoreFunctionRandom Seed
+  | FunctionScoreFunctionFieldValueFactor FieldValueFactor
+  deriving (Eq, Read, Show, Generic, Typeable)
+
+data FunctionScoreScript =
+  FunctionScoreScript { functionScoreScriptInline :: FunctionScoreScriptInline
+                      , functionScoreScriptParams :: Maybe FunctionScoreScriptParams
+                      } deriving (Eq, Read, Show, Generic, Typeable)
+
+newtype FunctionScoreScriptInline =
+  FunctionScoreScriptInline Text deriving (Eq, Read, Show, Generic, Typeable, ToJSON, FromJSON)
+
+newtype FunctionScoreScriptParams =
+  FunctionScoreScriptParams (HM.HashMap FunctionScoreScriptParamName FunctionScoreScriptParamValue)
+  deriving (Eq, Read, Show, Generic, Typeable)
+
+type FunctionScoreScriptParamName = Text
+type FunctionScoreScriptParamValue = Value
+
+newtype Weight =
+  Weight Float deriving (Eq, Read, Show, Generic, Typeable, ToJSON, FromJSON)
+
+newtype Seed =
+  Seed Float deriving (Eq, Read, Show, Generic, Typeable, ToJSON, FromJSON)
+
+data FieldValueFactor =
+  FieldValueFactor { fieldValueFactorField    :: FieldName
+                   , fieldValueFactor         :: Maybe Factor
+                   , fieldValueFactorModifier :: Maybe FactorModifier
+                   , fieldValueFactorMissing  :: Maybe FactorMissingFieldValue
+                   } deriving (Eq, Read, Show, Generic, Typeable)
+
+newtype Factor =
+  Factor Float deriving (Eq, Read, Show, Generic, Typeable, ToJSON, FromJSON)
+
+data FactorModifier =
+  FactorModifierNone
+  | FactorModifierLog
+  | FactorModifierLog1p
+  | FactorModifierLog2p
+  | FactorModifierLn
+  | FactorModifierLn1p
+  | FactorModifierLn2p
+  | FactorModifierSquare
+  | FactorModifierSqrt
+  | FactorModifierReciprocal deriving (Eq, Read, Show, Generic, Typeable)
+
+newtype FactorMissingFieldValue =
+  FactorMissingFieldValue Float deriving (Eq, Read, Show, Generic, Typeable, ToJSON, FromJSON)
 
 data DisMaxQuery =
   DisMaxQuery { disMaxQueries    :: [Query]
@@ -2219,6 +2325,9 @@ instance ToJSON Query where
     object ["constant_score" .= object ["query" .= query
                                        , "boost" .= boost]]
 
+  toJSON (QueryFunctionScoreQuery functionScoreQuery) =
+    object [ "function_score" .= functionScoreQuery ]
+
   toJSON (QueryDisMaxQuery disMaxQuery) =
     object [ "dis_max" .= disMaxQuery ]
 
@@ -2286,6 +2395,7 @@ instance FromJSON Query where
                 <|> queryBoostingQuery `taggedWith` "boosting"
                 <|> queryCommonTermsQuery `taggedWith` "common"
                 <|> constantScoreQuery `taggedWith` "constant_score"
+                <|> queryFunctionScoreQuery `taggedWith` "function_score"
                 <|> queryDisMaxQuery `taggedWith` "dis_max"
                 <|> queryFuzzyLikeThisQuery `taggedWith` "fuzzy_like_this"
                 <|> queryFuzzyLikeFieldQuery `taggedWith` "fuzzy_like_this_field"
@@ -2323,6 +2433,7 @@ instance FromJSON Query where
             Just x -> ConstantScoreQuery <$> parseJSON x
                                          <*> o .: "boost"
             _ -> fail "Does not appear to be a ConstantScoreQuery"
+          queryFunctionScoreQuery = pure . QueryFunctionScoreQuery
           queryDisMaxQuery = pure . QueryDisMaxQuery
           queryFuzzyLikeThisQuery = pure . QueryFuzzyLikeThisQuery
           queryFuzzyLikeFieldQuery = pure . QueryFuzzyLikeFieldQuery
@@ -2735,6 +2846,171 @@ instance FromJSON FuzzyLikeThisQuery where
                     <*> o .: "prefix_length"
                     <*> o .: "boost"
                     <*> o .:? "analyzer"
+
+instance ToJSON FunctionScoreQuery where
+  toJSON (FunctionScoreQuery query boost fns maxBoost boostMode minScore scoreMode) =
+    omitNulls base
+    where base = functionScoreFunctionsPair fns :
+                 [ "query"      .= query
+                 , "boost"      .= boost
+                 , "max_boost"  .= maxBoost
+                 , "boost_mode" .= boostMode
+                 , "min_score"  .= minScore
+                 , "score_mode" .= scoreMode ]
+
+functionScoreFunctionsPair :: FunctionScoreFunctions -> (Text, Value)
+functionScoreFunctionsPair (FunctionScoreSingle fn)
+  = functionScoreFunctionPair fn
+
+functionScoreFunctionsPair (FunctionScoreMultiple componentFns) =
+  ("functions", toJSON componentFns)
+
+instance FromJSON FunctionScoreQuery where
+  parseJSON = withObject "FunctionScoreQuery" parse
+    where parse o = FunctionScoreQuery
+                    <$> o .:? "query"
+                    <*> o .:? "boost"
+                    <*> (singleFunction o
+                          <|> multipleFunctions `taggedWith` "functions")
+                    <*> o .:? "max_boost"
+                    <*> o .:? "boost_mode"
+                    <*> o .:? "min_score"
+                    <*> o .:? "score_mode"
+            where taggedWith parser k = parser =<< o .: k
+          singleFunction = fmap FunctionScoreSingle . parseFunctionScoreFunction
+          multipleFunctions = pure . FunctionScoreMultiple
+
+instance ToJSON BoostMode where
+  toJSON BoostModeMultiply = "multiply"
+  toJSON BoostModeReplace  = "replace"
+  toJSON BoostModeSum      = "sum"
+  toJSON BoostModeAvg      = "avg"
+  toJSON BoostModeMax      = "max"
+  toJSON BoostModeMin      = "min"
+
+instance FromJSON BoostMode where
+  parseJSON = withText "BoostMode" parse
+    where parse "multiply" = pure BoostModeMultiply
+          parse "replace"  = pure BoostModeReplace
+          parse "sum"      = pure BoostModeSum
+          parse "avg"      = pure BoostModeAvg
+          parse "max"      = pure BoostModeMax
+          parse "min"      = pure BoostModeMin
+          parse bm         = fail ("Unexpected BoostMode: " <> show bm)
+
+instance ToJSON ScoreMode where
+  toJSON ScoreModeMultiply = "multiply"
+  toJSON ScoreModeSum      = "sum"
+  toJSON ScoreModeFirst    = "first"
+  toJSON ScoreModeAvg      = "avg"
+  toJSON ScoreModeMax      = "max"
+  toJSON ScoreModeMin      = "min"
+
+instance FromJSON ScoreMode where
+  parseJSON = withText "ScoreMode" parse
+    where parse "multiply" = pure ScoreModeMultiply
+          parse "sum"      = pure ScoreModeSum
+          parse "first"    = pure ScoreModeFirst
+          parse "avg"      = pure ScoreModeAvg
+          parse "max"      = pure ScoreModeMax
+          parse "min"      = pure ScoreModeMin
+          parse sm         = fail ("Unexpected ScoreMode: " <> show sm)
+
+instance ToJSON ComponentFunctionScoreFunction where
+  toJSON (ComponentFunctionScoreFunction filter fn weight) =
+    omitNulls base
+    where base = functionScoreFunctionPair fn :
+                 [ "filter" .= filter
+                 , "weight" .= weight ]
+
+instance FromJSON ComponentFunctionScoreFunction where
+  parseJSON = withObject "ComponentFunctionScoreFunction" parse
+    where parse o = ComponentFunctionScoreFunction
+                    <$> o .:? "filter"
+                    <*> parseFunctionScoreFunction o
+                    <*> o .:? "weight"
+
+functionScoreFunctionPair :: FunctionScoreFunction -> (Text, Value)
+functionScoreFunctionPair (FunctionScoreFunctionScript functionScoreScript) =
+  ("script_score", toJSON functionScoreScript)
+
+functionScoreFunctionPair (FunctionScoreFunctionRandom seed) =
+  ("random_score", omitNulls [ "seed" .= seed ])
+
+functionScoreFunctionPair (FunctionScoreFunctionFieldValueFactor fieldValueFactor) =
+  ("field_value_factor", toJSON fieldValueFactor)
+
+parseFunctionScoreFunction :: Object -> Parser FunctionScoreFunction
+parseFunctionScoreFunction o =
+  singleScript `taggedWith` "script_score"
+  <|> singleRandom `taggedWith` "random_score"
+  <|> singleFieldValueFactor `taggedWith` "field_value_factor"
+  where taggedWith parser k = parser =<< o .: k
+        singleScript = pure . FunctionScoreFunctionScript
+        singleRandom o' = FunctionScoreFunctionRandom <$> o' .: "seed"
+        singleFieldValueFactor = pure . FunctionScoreFunctionFieldValueFactor
+
+instance ToJSON FunctionScoreScript where
+  toJSON (FunctionScoreScript inline params) =
+    object [ "script" .= omitNulls base ]
+    where base = [ "inline" .= inline
+                 , "params" .= params ]
+
+instance FromJSON FunctionScoreScript where
+  parseJSON = withObject "FunctionScoreScript" parse
+    where parse o = o .: "script" >>= \o' ->
+                      FunctionScoreScript
+                      <$> o' .: "inline"
+                      <*> o' .:? "params"
+
+instance ToJSON FunctionScoreScriptParams where
+  toJSON (FunctionScoreScriptParams x) = Object x
+
+instance FromJSON FunctionScoreScriptParams where
+  parseJSON (Object o) = pure (FunctionScoreScriptParams o)
+  parseJSON _          = fail "error parsing FunctionScoreScriptParams"
+
+instance ToJSON FieldValueFactor where
+  toJSON (FieldValueFactor field factor modifier missing) =
+    omitNulls base
+    where base = [ "field"    .= field
+                 , "factor"   .= factor
+                 , "modifier" .= modifier
+                 , "missing"  .= missing ]
+
+instance FromJSON FieldValueFactor where
+  parseJSON = withObject "FieldValueFactor" parse
+    where parse o = FieldValueFactor
+                    <$> o .: "field"
+                    <*> o .:? "factor"
+                    <*> o .:? "modifier"
+                    <*> o .:? "missing"
+
+instance ToJSON FactorModifier where
+  toJSON FactorModifierNone       = "none"
+  toJSON FactorModifierLog        = "log"
+  toJSON FactorModifierLog1p      = "log1p"
+  toJSON FactorModifierLog2p      = "log2p"
+  toJSON FactorModifierLn         = "ln"
+  toJSON FactorModifierLn1p       = "ln1p"
+  toJSON FactorModifierLn2p       = "ln2p"
+  toJSON FactorModifierSquare     = "square"
+  toJSON FactorModifierSqrt       = "sqrt"
+  toJSON FactorModifierReciprocal = "reciprocal"
+
+instance FromJSON FactorModifier where
+  parseJSON = withText "FactorModifier" parse
+    where parse "none"       = pure FactorModifierNone
+          parse "log"        = pure FactorModifierLog
+          parse "log1p"      = pure FactorModifierLog1p
+          parse "log2p"      = pure FactorModifierLog2p
+          parse "ln"         = pure FactorModifierLn
+          parse "ln1p"       = pure FactorModifierLn1p
+          parse "ln2p"       = pure FactorModifierLn2p
+          parse "square"     = pure FactorModifierSquare
+          parse "sqrt"       = pure FactorModifierSqrt
+          parse "reciprocal" = pure FactorModifierReciprocal
+          parse fm           = fail ("Unexpected FactorModifier: " <> show fm)
 
 instance ToJSON DisMaxQuery where
   toJSON (DisMaxQuery queries tiebreaker boost) =

--- a/tests/V5/tests.hs
+++ b/tests/V5/tests.hs
@@ -559,6 +559,21 @@ instance ApproxEq HasChildQuery
 instance ApproxEq FuzzyQuery
 instance ApproxEq FuzzyLikeFieldQuery
 instance ApproxEq FuzzyLikeThisQuery
+instance ApproxEq FunctionScoreQuery
+instance ApproxEq BoostMode
+instance ApproxEq ScoreMode
+instance ApproxEq FunctionScoreFunctions
+instance ApproxEq ComponentFunctionScoreFunction
+instance ApproxEq FunctionScoreFunction
+instance ApproxEq FunctionScoreScript
+instance ApproxEq FunctionScoreScriptInline
+instance ApproxEq FunctionScoreScriptParams where (=~) = (==)
+instance ApproxEq Weight where (=~) = (==)
+instance ApproxEq Seed where (=~) = (==)
+instance ApproxEq FieldValueFactor
+instance ApproxEq Factor where (=~) = (==)
+instance ApproxEq FactorModifier
+instance ApproxEq FactorMissingFieldValue where (=~) = (==)
 instance ApproxEq DisMaxQuery
 instance ApproxEq CommonTermsQuery
 instance ApproxEq CommonMinimumMatch
@@ -770,7 +785,7 @@ instance Arbitrary Query where
   shrink = genericShrink
 
 instance Arbitrary Filter where
-  arbitrary = Filter <$> arbitrary 
+  arbitrary = Filter <$> arbitrary
   shrink = genericShrink
 
 instance Arbitrary ReplicaBounds where
@@ -866,6 +881,28 @@ instance Arbitrary HasChildQuery where arbitrary = sopArbitrary; shrink = generi
 instance Arbitrary FuzzyQuery where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary FuzzyLikeFieldQuery where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary FuzzyLikeThisQuery where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary FunctionScoreQuery where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary BoostMode where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary ScoreMode where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary FunctionScoreFunctions where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary ComponentFunctionScoreFunction where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary FunctionScoreFunction where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary FunctionScoreScript where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary FunctionScoreScriptInline where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary FunctionScoreScriptParams where
+  arbitrary =
+    pure $ FunctionScoreScriptParams $
+      HM.fromList [ ("a", Number 42)
+                  , ("b", String "forty two")
+                  ]
+
+  shrink = const []
+instance Arbitrary Weight where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary Seed where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary FieldValueFactor where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary Factor where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary FactorModifier where arbitrary = sopArbitrary; shrink = genericShrink
+instance Arbitrary FactorMissingFieldValue where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary DisMaxQuery where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary CommonTermsQuery where arbitrary = sopArbitrary; shrink = genericShrink
 instance Arbitrary DistanceRange where arbitrary = sopArbitrary; shrink = genericShrink
@@ -1672,6 +1709,13 @@ main = hspec $ do
     propJSON (Proxy :: Proxy FuzzyQuery)
     propJSON (Proxy :: Proxy FuzzyLikeFieldQuery)
     propJSON (Proxy :: Proxy FuzzyLikeThisQuery)
+    propJSON (Proxy :: Proxy FunctionScoreQuery)
+    propJSON (Proxy :: Proxy BoostMode)
+    propJSON (Proxy :: Proxy ScoreMode)
+    propJSON (Proxy :: Proxy ComponentFunctionScoreFunction)
+    propJSON (Proxy :: Proxy FunctionScoreScript)
+    propJSON (Proxy :: Proxy FieldValueFactor)
+    propJSON (Proxy :: Proxy FactorModifier)
     propJSON (Proxy :: Proxy DisMaxQuery)
     propJSON (Proxy :: Proxy CommonTermsQuery)
     propJSON (Proxy :: Proxy CommonMinimumMatch)


### PR DESCRIPTION
This PR adds (`V5`) support for:

* `function_score` (https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html), currently supporting inline scripts, stored scripts and all functions except decay functions.
* `script_fields` (https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html), returned in `hits` under `fields`.

Things missing/work-in-progress/issues:

* This is probably a breaking change since the `Script` type has been elaborated to support more than the `inline` case it previously exclusively catered for.
* Documentation for new types.
* `V1` support (not sure if required to get this merged).
* More comprehensive testing (currently I've added the bare-minimum round-trip JSON tests).