### PR TITLE
Examples TweetMapping fix structure

### DIFF
--- a/examples/Tweet.hs
+++ b/examples/Tweet.hs
@@ -25,9 +25,11 @@ data TweetMapping = TweetMapping deriving (Eq, Show)
 
 instance ToJSON TweetMapping where
   toJSON TweetMapping =
-    object
-      [ "properties" .=
-        object ["location" .= object ["type" .= ("geo_point" :: Text)]]
+    object ["tweet" .=
+      object
+        [ "properties" .=
+          object ["location" .= object ["type" .= ("geo_point" :: Text)]]
+        ]
       ]
 
 


### PR DESCRIPTION
The Tweet example failed due to TweetMapping not having the proper structure.
The error in ES5 is: 

> failed to put template [tweet-tpl]
org.elasticsearch.index.mapper.MapperParsingException: Failed to parse mapping [properties]: Root mapping definition has unsupported parameters:  [location : {type=geo_point}] 

