### PR TITLE
ES5 default for tests

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -22,11 +22,11 @@ source-repository head
 
 Flag ES1
   Description: Run the test suite against an Elasticsearch 1.x server
-  Default:     True
+  Default:     False
 
 Flag ES5
   Description: Run the test suite against an Elasticsearch 5.x server
-  Default:     False
+  Default:     True
 
 library
   ghc-options:         -Wall
@@ -67,11 +67,11 @@ test-suite tests
   ghc-options: -Wall -fno-warn-orphans
   type: exitcode-stdio-1.0
   main-is: tests.hs
-  if flag(ES5)
-    hs-source-dirs:     tests/V5
-  else
+  if flag(ES1)
     hs-source-dirs:     tests/V1
-  
+  else
+    hs-source-dirs:     tests/V5
+
   build-depends:       base,
                        bloodhound,
                        bytestring,


### PR DESCRIPTION
It make more sense to have ES5 as default for tests rather than ES1.