### PR TITLE
Add support for token filters

### DIFF
--- a/src/Database/V5/Bloodhound/Types.hs
+++ b/src/Database/V5/Bloodhound/Types.hs
@@ -203,6 +203,7 @@ module Database.V5.Bloodhound.Types
        , CutoffFrequency(..)
        , Analyzer(..)
        , Tokenizer(..)
+       , TokenFilter(..)
        , MaxExpansions(..)
        , Lenient(..)
        , MatchQueryType(..)
@@ -381,8 +382,11 @@ module Database.V5.Bloodhound.Types
        , Analysis(..)
        , AnalyzerDefinition(..)
        , TokenizerDefinition(..)
+       , TokenFilterDefinition(..)
        , Ngram(..)
        , TokenChar(..)
+       , Shingle(..)
+       , Language(..)
          ) where
 
 import           Control.Applicative                   as A
@@ -597,32 +601,244 @@ data UpdatableIndexSetting = NumberOfReplicas ReplicaCount
 data Analysis = Analysis
   { analysisAnalyzer :: M.Map Text AnalyzerDefinition
   , analysisTokenizer :: M.Map Text TokenizerDefinition
+  , analysisTokenFilter :: M.Map Text TokenFilterDefinition
   } deriving (Eq,Show,Generic,Typeable)
 
 instance ToJSON Analysis where
-  toJSON (Analysis analyzer tokenizer) = object
+  toJSON (Analysis analyzer tokenizer tokenFilter) = object
     [ "analyzer" .= analyzer
     , "tokenizer" .= tokenizer
+    , "filter" .= tokenFilter
     ]
 
 instance FromJSON Analysis where
   parseJSON = withObject "Analysis" $ \m -> Analysis
     <$> m .: "analyzer"
-    <*> m .: "tokenizer"
+    <*> m .:? "tokenizer" .!= M.empty
+    <*> m .:? "filter" .!= M.empty
 
 data AnalyzerDefinition = AnalyzerDefinition
   { analyzerDefinitionTokenizer :: Maybe Tokenizer
+  , analyzerDefinitionFilter :: [TokenFilter]
   } deriving (Eq,Show,Generic,Typeable)
 
 instance ToJSON AnalyzerDefinition where
-  toJSON (AnalyzerDefinition tokenizer) = object $ catMaybes
+  toJSON (AnalyzerDefinition tokenizer tokenFilter) = object $ catMaybes
     [ fmap ("tokenizer" .=) tokenizer
+    , Just $ "filter" .= tokenFilter
     ]
 
 instance FromJSON AnalyzerDefinition where
   parseJSON = withObject "AnalyzerDefinition" $ \m -> AnalyzerDefinition
     <$> m .:? "tokenizer"
+    <*> m .:? "filter" .!= []
   
+-- | Token filters are used to create custom analyzers.
+data TokenFilterDefinition
+  = TokenFilterDefinitionLowercase Language
+  | TokenFilterDefinitionUppercase Language
+  | TokenFilterDefinitionApostrophe
+  | TokenFilterDefinitionReverse
+  | TokenFilterDefinitionSnowball Language
+  | TokenFilterDefinitionShingle Shingle
+  deriving (Eq,Show,Generic)
+
+instance ToJSON TokenFilterDefinition where
+  toJSON x = case x of
+    TokenFilterDefinitionLowercase lang -> object
+      [ "type" .= ("lowercase" :: Text)
+      , "language" .= languageToText lang
+      ]
+    TokenFilterDefinitionUppercase lang -> object
+      [ "type" .= ("uppercase" :: Text)
+      , "language" .= languageToText lang
+      ]
+    TokenFilterDefinitionApostrophe -> object
+      [ "type" .= ("apostrophe" :: Text)
+      ]
+    TokenFilterDefinitionReverse -> object
+      [ "type" .= ("reverse" :: Text)
+      ]
+    TokenFilterDefinitionSnowball lang -> object
+      [ "type" .= ("snowball" :: Text)
+      , "language" .= languageToText lang
+      ]
+    TokenFilterDefinitionShingle s -> object
+      [ "type" .= ("shingle" :: Text)
+      , "max_shingle_size" .= shingleMaxSize s
+      , "min_shingle_size" .= shingleMinSize s
+      , "output_unigrams" .= shingleOutputUnigrams s
+      , "output_unigrams_if_no_shingles" .= shingleOutputUnigramsIfNoShingles s
+      , "token_separator" .= shingleTokenSeparator s
+      , "filler_token" .= shingleFillerToken s
+      ]
+
+instance FromJSON TokenFilterDefinition where
+  parseJSON = withObject "TokenFilterDefinition" $ \m -> do
+    t <- m .: "type"
+    case (t :: Text) of
+      "reverse" -> return TokenFilterDefinitionReverse
+      "apostrophe" -> return TokenFilterDefinitionApostrophe
+      "lowercase" -> TokenFilterDefinitionLowercase
+        <$> m .:? "language" .!= English
+      "uppercase" -> TokenFilterDefinitionUppercase
+        <$> m .:? "language" .!= English
+      "snowball" -> TokenFilterDefinitionSnowball
+        <$> m .:? "language" .!= English
+      "shingle" -> fmap TokenFilterDefinitionShingle $ Shingle
+        <$> (fmap.fmap) unStringlyTypedInt (m .:? "max_shingle_size") .!= 2
+        <*> (fmap.fmap) unStringlyTypedInt (m .:? "min_shingle_size") .!= 2
+        <*> (fmap.fmap) unStringlyTypedBool (m .:? "output_unigrams") .!= True
+        <*> (fmap.fmap) unStringlyTypedBool (m .:? "output_unigrams_if_no_shingles") .!= False
+        <*> m .:? "token_separator" .!= " "
+        <*> m .:? "filler_token" .!= "_"
+      _ -> fail ("unrecognized token filter type: " ++ T.unpack t)
+
+-- | The set of languages that can be passed to various analyzers,
+--   filters, etc. in ElasticSearch. Most data types in this module
+--   that have a 'Language' field are actually only actually to
+--   handle a subset of these languages. Consult the official
+--   ElasticSearch documentation to see what is actually supported.
+data Language
+  = Arabic
+  | Armenian
+  | Basque
+  | Bengali
+  | Brazilian
+  | Bulgarian
+  | Catalan
+  | Cjk
+  | Czech
+  | Danish
+  | Dutch
+  | English
+  | Finnish
+  | French
+  | Galician
+  | German
+  | German2
+  | Greek
+  | Hindi
+  | Hungarian
+  | Indonesian
+  | Irish
+  | Italian
+  | Kp
+  | Latvian
+  | Lithuanian
+  | Lovins
+  | Norwegian
+  | Persian
+  | Porter
+  | Portuguese
+  | Romanian
+  | Russian
+  | Sorani
+  | Spanish
+  | Swedish
+  | Thai
+  | Turkish
+  deriving (Show,Eq,Generic)
+
+instance ToJSON Language where
+  toJSON = Data.Aeson.String . languageToText
+
+instance FromJSON Language where
+  parseJSON = withText "Language" $ \t -> case languageFromText t of
+    Nothing -> fail "not a supported ElasticSearch language"
+    Just lang -> return lang
+
+languageToText :: Language -> Text
+languageToText x = case x of
+  Arabic -> "arabic"
+  Armenian -> "armenian"
+  Basque -> "basque"
+  Bengali -> "bengali"
+  Brazilian -> "brazilian"
+  Bulgarian -> "bulgarian"
+  Catalan -> "catalan"
+  Cjk -> "cjk"
+  Czech -> "czech"
+  Danish -> "danish"
+  Dutch -> "dutch"
+  English -> "english"
+  Finnish -> "finnish"
+  French -> "french"
+  Galician -> "galician"
+  German -> "german"
+  German2 -> "german2"
+  Greek -> "greek"
+  Hindi -> "hindi"
+  Hungarian -> "hungarian"
+  Indonesian -> "indonesian"
+  Irish -> "irish"
+  Italian -> "italian"
+  Kp -> "kp"
+  Latvian -> "latvian"
+  Lithuanian -> "lithuanian"
+  Lovins -> "lovins"
+  Norwegian -> "norwegian"
+  Persian -> "persian"
+  Porter -> "porter"
+  Portuguese -> "portuguese"
+  Romanian -> "romanian"
+  Russian -> "russian"
+  Sorani -> "sorani"
+  Spanish -> "spanish"
+  Swedish -> "swedish"
+  Thai -> "thai"
+  Turkish -> "turkish"
+
+languageFromText :: Text -> Maybe Language
+languageFromText x = case x of
+  "arabic" -> Just Arabic
+  "armenian" -> Just Armenian
+  "basque" -> Just Basque
+  "bengali" -> Just Bengali
+  "brazilian" -> Just Brazilian
+  "bulgarian" -> Just Bulgarian
+  "catalan" -> Just Catalan
+  "cjk" -> Just Cjk
+  "czech" -> Just Czech
+  "danish" -> Just Danish
+  "dutch" -> Just Dutch
+  "english" -> Just English
+  "finnish" -> Just Finnish
+  "french" -> Just French
+  "galician" -> Just Galician
+  "german" -> Just German
+  "german2" -> Just German2
+  "greek" -> Just Greek
+  "hindi" -> Just Hindi
+  "hungarian" -> Just Hungarian
+  "indonesian" -> Just Indonesian
+  "irish" -> Just Irish
+  "italian" -> Just Italian
+  "kp" -> Just Kp
+  "latvian" -> Just Latvian
+  "lithuanian" -> Just Lithuanian
+  "lovins" -> Just Lovins
+  "norwegian" -> Just Norwegian
+  "persian" -> Just Persian
+  "porter" -> Just Porter
+  "portuguese" -> Just Portuguese
+  "romanian" -> Just Romanian
+  "russian" -> Just Russian
+  "sorani" -> Just Sorani
+  "spanish" -> Just Spanish
+  "swedish" -> Just Swedish
+  "thai" -> Just Thai
+  "turkish" -> Just Turkish
+  _ -> Nothing
+
+data Shingle = Shingle
+  { shingleMaxSize :: Int
+  , shingleMinSize :: Int
+  , shingleOutputUnigrams :: Bool
+  , shingleOutputUnigramsIfNoShingles :: Bool
+  , shingleTokenSeparator :: Text
+  , shingleFillerToken :: Text
+  } deriving (Eq,Show,Generic,Typeable)
 
 data TokenizerDefinition
   = TokenizerDefinitionNgram Ngram
@@ -1110,6 +1326,8 @@ newtype Analyzer =
   Analyzer Text deriving (Eq, Read, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype Tokenizer =
   Tokenizer Text deriving (Eq, Read, Show, Generic, ToJSON, FromJSON, Typeable)
+newtype TokenFilter =
+  TokenFilter Text deriving (Eq, Read, Show, Generic, ToJSON, FromJSON, Typeable)
 newtype MaxExpansions =
   MaxExpansions Int deriving (Eq, Read, Show, Generic, ToJSON, FromJSON, Typeable)
 
@@ -4750,6 +4968,11 @@ newtype StringlyTypedInt = StringlyTypedInt { unStringlyTypedInt :: Int }
 
 instance FromJSON StringlyTypedInt where
   parseJSON = fmap StringlyTypedInt . parseJSON . unStringlyTypeJSON
+
+newtype StringlyTypedBool = StringlyTypedBool { unStringlyTypedBool :: Bool }
+
+instance FromJSON StringlyTypedBool where
+  parseJSON = fmap StringlyTypedBool . parseJSON . unStringlyTypeJSON
 
 instance FromJSON NodeFSTotalStats where
   parseJSON = withObject "NodeFSTotalStats" parse

--- a/src/Database/V5/Bloodhound/Types.hs
+++ b/src/Database/V5/Bloodhound/Types.hs
@@ -635,8 +635,8 @@ instance FromJSON AnalyzerDefinition where
   
 -- | Token filters are used to create custom analyzers.
 data TokenFilterDefinition
-  = TokenFilterDefinitionLowercase Language
-  | TokenFilterDefinitionUppercase Language
+  = TokenFilterDefinitionLowercase (Maybe Language)
+  | TokenFilterDefinitionUppercase (Maybe Language)
   | TokenFilterDefinitionApostrophe
   | TokenFilterDefinitionReverse
   | TokenFilterDefinitionSnowball Language
@@ -645,13 +645,13 @@ data TokenFilterDefinition
 
 instance ToJSON TokenFilterDefinition where
   toJSON x = case x of
-    TokenFilterDefinitionLowercase lang -> object
-      [ "type" .= ("lowercase" :: Text)
-      , "language" .= languageToText lang
+    TokenFilterDefinitionLowercase mlang -> object $ catMaybes
+      [ Just $ "type" .= ("lowercase" :: Text)
+      , fmap (\lang -> "language" .= languageToText lang) mlang
       ]
-    TokenFilterDefinitionUppercase lang -> object
-      [ "type" .= ("uppercase" :: Text)
-      , "language" .= languageToText lang
+    TokenFilterDefinitionUppercase mlang -> object $ catMaybes
+      [ Just $ "type" .= ("uppercase" :: Text)
+      , fmap (\lang -> "language" .= languageToText lang) mlang
       ]
     TokenFilterDefinitionApostrophe -> object
       [ "type" .= ("apostrophe" :: Text)
@@ -680,11 +680,11 @@ instance FromJSON TokenFilterDefinition where
       "reverse" -> return TokenFilterDefinitionReverse
       "apostrophe" -> return TokenFilterDefinitionApostrophe
       "lowercase" -> TokenFilterDefinitionLowercase
-        <$> m .:? "language" .!= English
+        <$> m .:? "language"
       "uppercase" -> TokenFilterDefinitionUppercase
-        <$> m .:? "language" .!= English
+        <$> m .:? "language"
       "snowball" -> TokenFilterDefinitionSnowball
-        <$> m .:? "language" .!= English
+        <$> m .: "language"
       "shingle" -> fmap TokenFilterDefinitionShingle $ Shingle
         <$> (fmap.fmap) unStringlyTypedInt (m .:? "max_shingle_size") .!= 2
         <*> (fmap.fmap) unStringlyTypedInt (m .:? "min_shingle_size") .!= 2

--- a/tests/V5/tests.hs
+++ b/tests/V5/tests.hs
@@ -1653,8 +1653,8 @@ main = hspec $ do
               )
             )
             (M.fromList
-              [ ("ex_filter_lowercase",TokenFilterDefinitionLowercase Greek)
-              , ("ex_filter_uppercase",TokenFilterDefinitionUppercase English)
+              [ ("ex_filter_lowercase",TokenFilterDefinitionLowercase (Just Greek))
+              , ("ex_filter_uppercase",TokenFilterDefinitionUppercase Nothing)
               , ("ex_filter_apostrophe",TokenFilterDefinitionApostrophe)
               , ("ex_filter_reverse",TokenFilterDefinitionReverse)
               , ("ex_filter_snowball",TokenFilterDefinitionSnowball English)


### PR DESCRIPTION
Add support for token filters. The supported filters include: lowercase, uppercase, shingle, snowball, apostrophe, and reverse. This PR also adds tests for all of these.