### PR TITLE
Allow http-types-0.12

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -55,7 +55,7 @@ library
                        text             >= 0.11    && <1.3,
                        mtl              >= 1.0     && <2.3,
                        transformers     >= 0.2     && <0.6,
-                       http-types       >= 0.8     && <0.12,
+                       http-types       >= 0.8     && <0.13,
                        vector           >= 0.10.9  && <0.13,
                        scientific       >= 0.3.0.0 && <0.4.0.0,
                        exceptions,

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -6,7 +6,6 @@ packages:
   - '.'
   - './examples'
 
-extra-deps:
-  - http-types-0.11
+extra-deps: []
 
 resolver: lts-10.0

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -6,6 +6,7 @@ packages:
   - '.'
   - './examples'
 
-extra-deps: []
+extra-deps:
+  - http-types-0.12
 
 resolver: lts-10.0


### PR DESCRIPTION
I tested this locally, but I'm not really sure its the right thing to
put http-types in the default stack.yaml

This is for https://github.com/fpco/stackage/issues/3232 which blocks
us in katip-elasticsearch downstream

Update: @bitemyapp I noticed you actually put the http-types-0.11 in the stack.yaml in the last commit. Should I instead put 0.12 in the stack.yaml? Wasn't sure about the policy but I may have guessed wrong.