### PR TITLE
Multifield querystring

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -1,5 +1,5 @@
 name:                bloodhound
-version:             0.15.1.0
+version:             0.15.2.0
 synopsis:            ElasticSearch client library for Haskell
 description:         ElasticSearch made awesome for Haskell hackers
 homepage:            https://github.com/bitemyapp/bloodhound

--- a/src/Database/V1/Bloodhound/Types.hs
+++ b/src/Database/V1/Bloodhound/Types.hs
@@ -1288,6 +1288,9 @@ data QueryStringQuery =
   , queryStringMinimumShouldMatch       :: Maybe MinimumMatch
   , queryStringLenient                  :: Maybe Lenient
   , queryStringLocale                   :: Maybe Locale
+  , queryStringFields                   :: [FieldName]
+  , queryStringTiebreaker               :: Maybe Tiebreaker
+  , queryStringQueryType                :: Maybe MultiMatchQueryType
   } deriving (Eq, Read, Show, Generic, Typeable)
 
 mkQueryStringQuery :: QueryString -> QueryStringQuery
@@ -1296,7 +1299,8 @@ mkQueryStringQuery qs =
   Nothing Nothing Nothing Nothing
   Nothing Nothing Nothing Nothing
   Nothing Nothing Nothing Nothing
-  Nothing Nothing
+  Nothing Nothing [] Nothing
+  Nothing
 
 data FieldOrFields = FofField   FieldName
                    | FofFields (NonEmpty FieldName) deriving (Eq, Read, Show, Generic, Typeable)
@@ -2627,7 +2631,9 @@ instance ToJSON QueryStringQuery where
           qsFuzzyPrefixLength qsPhraseSlop
           qsBoost qsAnalyzeWildcard
           qsGeneratePhraseQueries qsMinimumShouldMatch
-          qsLenient qsLocale) =
+          qsLenient qsLocale
+          qsFields qsTiebreaker
+          qsType) =
     omitNulls base
     where
       base = [ "query" .= qsQueryString
@@ -2646,7 +2652,10 @@ instance ToJSON QueryStringQuery where
              , "auto_generate_phrase_queries" .= qsGeneratePhraseQueries
              , "minimum_should_match" .= qsMinimumShouldMatch
              , "lenient" .= qsLenient
-             , "locale" .= qsLocale ]
+             , "locale" .= qsLocale 
+             , "fields" .= fmap toJSON qsFields
+             , "tie_breaker" .= qsTiebreaker
+             , "type" .= qsType ]
 
 instance FromJSON QueryStringQuery where
   parseJSON = withObject "QueryStringQuery" parse
@@ -2668,6 +2677,9 @@ instance FromJSON QueryStringQuery where
                     <*> o .:? "minimum_should_match"
                     <*> o .:? "lenient"
                     <*> o .:? "locale"
+                    <*> o .:? "fields" .!= []
+                    <*> o .:? "tie_breaker"
+                    <*> o .:? "type"
 
 instance ToJSON RangeQuery where
   toJSON (RangeQuery (FieldName fieldName) range boost) =


### PR DESCRIPTION
Hi, I added support for multi fields in query string queries (https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-query-string-query.html#_multi_field)
for both versions.