### PR TITLE
Match query fuzziness

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,9 +18,13 @@
   - Add the "stemmer" and "stop" [token filters][] to `TokenFilterDefinition`.
 - @ahodgen
   - Add support for wildcard queries
+- @ashutoshrishi
+  - Added [fuzziness][] option to a Match Query
+  - Added support for "AUTO" Fuzziness alongside a numeric value.
 
 [Character Filters]: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/analysis-charfilters.html
 [Token Filters]: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/analysis-tokenfilters.html
+[Fuzziness]: https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness
 
 0.15.0.2
 ========

--- a/src/Database/V5/Bloodhound/Internal/Newtypes.hs
+++ b/src/Database/V5/Bloodhound/Internal/Newtypes.hs
@@ -110,8 +110,6 @@ newtype MinimumTermFrequency =
   MinimumTermFrequency Int deriving (Eq, Show, FromJSON, ToJSON)
 newtype MaxQueryTerms =
   MaxQueryTerms Int deriving (Eq, Show, FromJSON, ToJSON)
-newtype Fuzziness =
-  Fuzziness Double deriving (Eq, Show, FromJSON, ToJSON)
 
 {-| 'PrefixLength' is the prefix length used in queries, defaults to 0. -}
 newtype PrefixLength =

--- a/src/Database/V5/Bloodhound/Internal/Query.hs
+++ b/src/Database/V5/Bloodhound/Internal/Query.hs
@@ -845,6 +845,7 @@ data MatchQuery = MatchQuery
   , matchQueryLenient         :: Maybe Lenient
   , matchQueryBoost           :: Maybe Boost
   , matchQueryMinimumShouldMatch :: Maybe Text
+  , matchQueryFuzziness          :: Maybe Fuzziness
   } deriving (Eq, Show)
 
 
@@ -853,7 +854,7 @@ instance ToJSON MatchQuery where
           (QueryString mqQueryString) booleanOperator
           zeroTermsQuery cutoffFrequency matchQueryType
           analyzer maxExpansions lenient boost
-          minShouldMatch
+          minShouldMatch mqFuzziness
          ) =
     object [ fieldName .= omitNulls base ]
     where base = [ "query" .= mqQueryString
@@ -866,6 +867,7 @@ instance ToJSON MatchQuery where
                  , "lenient" .= lenient
                  , "boost" .= boost
                  , "minimum_should_match" .= minShouldMatch
+                 , "fuzziness" .= mqFuzziness
                  ]
 
 instance FromJSON MatchQuery where
@@ -882,12 +884,13 @@ instance FromJSON MatchQuery where
                     <*> o .:? "lenient"
                     <*> o .:? "boost"
                     <*> o .:? "minimum_should_match"
+                    <*> o .:? "fuzziness"
 
 {-| 'mkMatchQuery' is a convenience function that defaults the less common parameters,
     enabling you to provide only the 'FieldName' and 'QueryString' to make a 'MatchQuery'
 -}
 mkMatchQuery :: FieldName -> QueryString -> MatchQuery
-mkMatchQuery field query = MatchQuery field query Or ZeroTermsNone Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+mkMatchQuery field query = MatchQuery field query Or ZeroTermsNone Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 data MatchQueryType =
     MatchPhrase

--- a/src/Database/V5/Bloodhound/Internal/Query.hs
+++ b/src/Database/V5/Bloodhound/Internal/Query.hs
@@ -9,12 +9,12 @@ module Database.V5.Bloodhound.Internal.Query
 
 import           Bloodhound.Import
 
-import           Data.Char                                (isNumber)
-import qualified Data.HashMap.Strict                      as HM
-import           Data.List                                (nub)
-import qualified Data.Text                                as T
+import           Data.Char           (isNumber)
+import qualified Data.HashMap.Strict as HM
+import           Data.List           (nub)
+import qualified Data.Text           as T
 
-import           Database.Bloodhound.Common.Script        as X
+import           Database.Bloodhound.Common.Script as X
 import           Database.V5.Bloodhound.Internal.Newtypes
 
 data Query =
@@ -1625,7 +1625,9 @@ fieldTagged f o = case HM.toList o of
                     [(k, Object o')] -> f (FieldName k) o'
                     _ -> fail "Expected object with 1 field-named key"
 
-{-| Fuzziness value as a number or 'AUTO'. -}
+-- | Fuzziness value as a number or 'AUTO'.
+-- See:
+-- https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness
 data Fuzziness = Fuzziness Double | FuzzinessAuto
   deriving (Eq, Show)
 

--- a/src/Database/V5/Bloodhound/Internal/Query.hs
+++ b/src/Database/V5/Bloodhound/Internal/Query.hs
@@ -1624,3 +1624,16 @@ fieldTagged :: Monad m => (FieldName -> Object -> m a) -> Object -> m a
 fieldTagged f o = case HM.toList o of
                     [(k, Object o')] -> f (FieldName k) o'
                     _ -> fail "Expected object with 1 field-named key"
+
+{-| Fuzziness value as a number or 'AUTO'. -}
+data Fuzziness = Fuzziness Double | FuzzinessAuto
+  deriving (Eq, Show)
+
+instance ToJSON Fuzziness where
+  toJSON (Fuzziness n) = toJSON n
+  toJSON FuzzinessAuto = String "AUTO"
+
+instance FromJSON Fuzziness where
+  parseJSON (String "AUTO") = return FuzzinessAuto
+  parseJSON (String "auto") = return FuzzinessAuto
+  parseJSON v = Fuzziness <$> parseJSON v

--- a/src/Database/V5/Bloodhound/Internal/Query.hs
+++ b/src/Database/V5/Bloodhound/Internal/Query.hs
@@ -9,12 +9,12 @@ module Database.V5.Bloodhound.Internal.Query
 
 import           Bloodhound.Import
 
-import           Data.Char           (isNumber)
-import qualified Data.HashMap.Strict as HM
-import           Data.List           (nub)
-import qualified Data.Text           as T
+import           Data.Char                                (isNumber)
+import qualified Data.HashMap.Strict                      as HM
+import           Data.List                                (nub)
+import qualified Data.Text                                as T
 
-import           Database.Bloodhound.Common.Script as X
+import           Database.Bloodhound.Common.Script        as X
 import           Database.V5.Bloodhound.Internal.Newtypes
 
 data Query =
@@ -834,16 +834,16 @@ instance FromJSON DisMaxQuery where
                     <*> o .:? "boost"
 
 data MatchQuery = MatchQuery
-  { matchQueryField           :: FieldName
-  , matchQueryQueryString     :: QueryString
-  , matchQueryOperator        :: BooleanOperator
-  , matchQueryZeroTerms       :: ZeroTermsQuery
-  , matchQueryCutoffFrequency :: Maybe CutoffFrequency
-  , matchQueryMatchType       :: Maybe MatchQueryType
-  , matchQueryAnalyzer        :: Maybe Analyzer
-  , matchQueryMaxExpansions   :: Maybe MaxExpansions
-  , matchQueryLenient         :: Maybe Lenient
-  , matchQueryBoost           :: Maybe Boost
+  { matchQueryField              :: FieldName
+  , matchQueryQueryString        :: QueryString
+  , matchQueryOperator           :: BooleanOperator
+  , matchQueryZeroTerms          :: ZeroTermsQuery
+  , matchQueryCutoffFrequency    :: Maybe CutoffFrequency
+  , matchQueryMatchType          :: Maybe MatchQueryType
+  , matchQueryAnalyzer           :: Maybe Analyzer
+  , matchQueryMaxExpansions      :: Maybe MaxExpansions
+  , matchQueryLenient            :: Maybe Lenient
+  , matchQueryBoost              :: Maybe Boost
   , matchQueryMinimumShouldMatch :: Maybe Text
   , matchQueryFuzziness          :: Maybe Fuzziness
   } deriving (Eq, Show)
@@ -1635,5 +1635,4 @@ instance ToJSON Fuzziness where
 
 instance FromJSON Fuzziness where
   parseJSON (String "AUTO") = return FuzzinessAuto
-  parseJSON (String "auto") = return FuzzinessAuto
-  parseJSON v = Fuzziness <$> parseJSON v
+  parseJSON v               = Fuzziness <$> parseJSON v

--- a/tests/V5/Test/Query.hs
+++ b/tests/V5/Test/Query.hs
@@ -46,6 +46,15 @@ spec =
       liftIO $
         myTweet `shouldBe` Right exampleTweet
 
+    it "returns document for match query with fuzziness" $ withTestEnv $ do
+      _ <- insertData
+      let match = mkMatchQuery (FieldName "user") (QueryString "bidemyapp")
+      let query = QueryMatchQuery $ match { matchQueryFuzziness = Just FuzzinessAuto }
+      let search = mkSearch (Just query) Nothing
+      myTweet <- searchTweet search
+      liftIO $
+        myTweet `shouldBe` Right exampleTweet
+
     it "returns document for multi-match query" $ withTestEnv $ do
       _ <- insertData
       let flds = [FieldName "user", FieldName "message"]


### PR DESCRIPTION
This enables a "fuzziness" option for a Match Query: https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness

1. `MatchQuery` has a new field `matchQueryFuzziness` to add a "fuzziness" value
2. A `Fuzziness` value can be also created with an empty constructor FuzzinessAuto which sets fuzziness to a string value of "AUTO" 

I added a test for a fuzzy match query which works, but I am having trouble fixing some quick check JSON isomorphic tests. I have little experience with quick check and it ~~seems random properties fail~~ Never mind, it's all green here. 


Resolves #240 