### PR TITLE
Relax the dependency on containers and allow building the test suite with GHC 8.6

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -63,7 +63,7 @@ library
   other-modules:       Bloodhound.Import
                        Database.Bloodhound.Common.Script
   hs-source-dirs:      src
-  build-depends:       base             >= 4.3     && <5,
+  build-depends:       base             >= 4.9     && <5,
                        aeson            >= 0.11.1,
                        blaze-builder,
                        bytestring       >= 0.10.0  && <0.11,

--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -110,7 +110,7 @@ test-suite bloodhound-tests
                        Test.Suggest
                        Test.Templates
   build-depends:       base,
-                       QuickCheck,
+                       QuickCheck           < 2.12,
                        aeson,
                        bloodhound,
                        bytestring,

--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -67,7 +67,7 @@ library
                        aeson            >= 0.11.1,
                        blaze-builder,
                        bytestring       >= 0.10.0  && <0.11,
-                       containers       >= 0.5.0.0 && <0.6,
+                       containers       >= 0.5.0.0 && <0.7,
                        exceptions,
                        hashable,
                        http-client      >= 0.4.30  && <0.6,

--- a/src/Database/V1/Bloodhound/Internal/Client.hs
+++ b/src/Database/V1/Bloodhound/Internal/Client.hs
@@ -10,6 +10,7 @@ module Database.V1.Bloodhound.Internal.Client where
 import           Bloodhound.Import
 
 import           Control.Applicative                           as A
+import qualified Control.Monad.Fail                            as Fail
 import qualified Data.HashMap.Strict                           as HM
 import           Data.Text                                     (Text)
 import qualified Data.Text                                     as T
@@ -76,6 +77,7 @@ newtype BH m a = BH {
     } deriving ( Functor
                , A.Applicative
                , Monad
+               , Fail.MonadFail
                , MonadIO
                , MonadState s
                , MonadWriter w

--- a/src/Database/V5/Bloodhound/Internal/Client.hs
+++ b/src/Database/V5/Bloodhound/Internal/Client.hs
@@ -9,6 +9,7 @@ module Database.V5.Bloodhound.Internal.Client where
 
 import           Bloodhound.Import
 
+import qualified Control.Monad.Fail  as Fail
 import qualified Data.Text           as T
 import qualified Data.Traversable    as DT
 import qualified Data.HashMap.Strict as HM
@@ -62,6 +63,7 @@ newtype BH m a = BH {
     } deriving ( Functor
                , Applicative
                , Monad
+               , Fail.MonadFail
                , MonadIO
                , MonadState s
                , MonadWriter w

--- a/tests/V5/Test/Generators.hs
+++ b/tests/V5/Test/Generators.hs
@@ -210,8 +210,8 @@ instance Arbitrary NodeAttrName where
 instance Arbitrary NodeAttrFilter where
   arbitrary = do
     n <- arbitrary
-    s:ss <- listOf1 (listOf1 arbitraryAlphaNum)
-    let ts = T.pack <$> s :| ss
+    ss <- listOf1 (listOf1 arbitraryAlphaNum)
+    let ts = T.pack <$> head ss :| tail ss
     return (NodeAttrFilter n ts)
 
 instance Arbitrary VersionNumber where


### PR DESCRIPTION
NB: This PR drops support for GHC < 8. I'm not sure whether it is okay or not. Looks like there is no CI for GHC < 8, though.

Would be also nice if the dependency on `containers` was relaxed on Hackage or a new minor release with support for GHC 8.6 was uploaded.