### PR TITLE
Relax the dependency on http-client.

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -70,7 +70,7 @@ library
                        containers       >= 0.5.0.0 && <0.6,
                        exceptions,
                        hashable,
-                       http-client      >= 0.4.30  && <0.6,
+                       http-client      >= 0.4.30  && <0.7,
                        http-types       >= 0.8     && <0.13,
                        mtl              >= 1.0     && <2.3,
                        network-uri      >= 2.6     && <2.7,


### PR DESCRIPTION
`bloodhound` compiles against `http-client-0.6.1` and seems to work fine. The only breaking change in the new `http-client` was in the `renderParts` function, but it looks like `bloodhound` code doesn't make use of it.

Would be nice if you could make a Hackage revision too.