### PR TITLE
[WIP] Elasticsearch 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 env:
   matrix:
-    - GHCVER=8.6  ESVER=5.6.0 STACK_YAML=stack.yaml DLINK=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch ES_JAVA_OPTS="-Xms500m -Xmx750m"
+    - GHCVER=8.6 ESVER=7.3.1 STACK_YAML=stack.yaml DLINK=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch ES_JAVA_OPTS="-Xms500m -Xmx750m"
 
 install:
   # stack
@@ -20,11 +20,11 @@ install:
   - export PATH=~/.local/bin:$PATH
   - stack --no-terminal --version
   # elasticsearch
-  - wget --no-check-certificate $DLINK-$ESVER.tar.gz
-  - tar xzf elasticsearch-$ESVER.tar.gz
+  - wget --no-check-certificate $DLINK-$ESVER-linux-x86_64.tar.gz
+  - tar xzf elasticsearch-$ESVER-linux-x86_64.tar.gz
   # set up a repo for snapshot testing. Required in ES >= 1.6
-  - echo "path.repo = [\"/tmp\"]" >> ./elasticsearch-$ESVER/elasticsearch.yml
-  - ./elasticsearch-$ESVER/bin/elasticsearch &
+  - echo "path.repo = [\"/tmp\"]" >> ./elasticsearch-$ESVER-linux-x86_64/elasticsearch.yml
+  - ./elasticsearch-$ESVER-linux-x86_64/bin/elasticsearch &
 
 script:
   - stack setup --no-terminal

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
   - wget --no-check-certificate $DLINK-$ESVER-linux-x86_64.tar.gz
   - tar xzf elasticsearch-$ESVER-linux-x86_64.tar.gz
   # set up a repo for snapshot testing. Required in ES >= 1.6
-  - echo "path.repo = [\"/tmp\"]" >> ./elasticsearch-$ESVER-linux-x86_64/elasticsearch.yml
-  - ./elasticsearch-$ESVER-linux-x86_64/bin/elasticsearch &
+  - echo "path.repo = [\"/tmp\"]" >> ./elasticsearch-$ESVER/elasticsearch.yml
+  - ./elasticsearch-$ESVER/bin/elasticsearch &
 
 script:
   - stack setup --no-terminal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,12 @@
-version: "2"
+version: "2.2"
 services:
   elasticsearch1:
-    build: .
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.1
     container_name: elasticsearch1
     environment:
+      - node.name=elasticsearch1
+      - discovery.seed_hosts=elasticsearch2
+      - cluster.initial_master_nodes=elasticsearch1,elasticsearch2
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -12,24 +15,37 @@ services:
         soft: -1
         hard: -1
     mem_limit: 1g
+    volumes:
+      - esdata01:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
     networks:
       - esnet
   elasticsearch2:
-    build: .
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.1
+    container_name: elasticsearch2
     environment:
+      - node.name=elasticsearch2
+      - discovery.seed_hosts=elasticsearch1
+      - cluster.initial_master_nodes=elasticsearch1,elasticsearch2
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "discovery.zen.ping.unicast.hosts=elasticsearch1"
     ulimits:
       memlock:
         soft: -1
         hard: -1
     mem_limit: 1g
+    volumes:
+      - esdata02:/usr/share/elasticsearch/data
     networks:
       - esnet
 
+volumes:
+  esdata01:
+    driver: local
+  esdata02:
+    driver: local
+
 networks:
-  esnet: {}
+  esnet: 

--- a/examples/Tweet.hs
+++ b/examples/Tweet.hs
@@ -63,7 +63,7 @@ main = runBH' $ do
   _ <- putMapping testIndex testMapping TweetMapping
 
   -- create a tweet
-  resp <- indexDocument testIndex testMapping defaultIndexDocumentSettings exampleTweet (DocId "1")
+  resp <- indexDocument testIndex defaultIndexDocumentSettings exampleTweet (DocId "1")
   liftIO (print resp)
   -- Response {responseStatus = Status {statusCode = 201, statusMessage = "Created"}, responseVersion = HTTP/1.1, responseHeaders = [("Content-Type","application/json; charset=UTF-8"),("Content-Length","74")], responseBody = "{\"_index\":\"twitter\",\"_type\":\"tweet\",\"_id\":\"1\",\"_version\":1,\"created\":true}", responseCookieJar = CJ {expose = []}, responseClose' = ResponseClose}
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,1 @@
+cradle: {stack: { component: "bloodhound" }}

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -831,12 +831,11 @@ versionCtlParams cfg =
 -- >>> resp <- runBH' $ indexDocument testIndex testMapping defaultIndexDocumentSettings exampleTweet (DocId "1")
 -- >>> print resp
 -- Response {responseStatus = Status {statusCode = 201, statusMessage = "Created"}, responseVersion = HTTP/1.1, responseHeaders = [("Location","/twitter/tweet/1"),("content-type","application/json; charset=UTF-8"),("content-encoding","gzip"),("transfer-encoding","chunked")], responseBody = "{\"_index\":\"twitter\",\"_type\":\"tweet\",\"_id\":\"1\",\"_version\":1,\"result\":\"created\",\"_shards\":{\"total\":2,\"successful\":1,\"failed\":0},\"created\":true}", responseCookieJar = CJ {expose = []}, responseClose' = ResponseClose}
-indexDocument :: (ToJSON doc, MonadBH m) => IndexName -> MappingName
+indexDocument :: (ToJSON doc, MonadBH m) => IndexName
                  -> IndexDocumentSettings -> doc -> DocId -> m Reply
-indexDocument (IndexName indexName)
-  (MappingName mappingName) cfg document (DocId docId) =
+indexDocument (IndexName indexName) cfg document (DocId docId) =
   bindM2 put url (return body)
-  where url = addQuery params <$> joinPath [indexName, mappingName, docId]
+  where url = addQuery params <$> joinPath [indexName, "_create", docId]
         parentParams = case idsParent cfg of
           Nothing -> []
           Just (DocumentParent (DocId p)) -> [ ("parent", Just p) ]

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -834,7 +834,7 @@ versionCtlParams cfg =
 indexDocument :: (ToJSON doc, MonadBH m) => IndexName
                  -> IndexDocumentSettings -> doc -> DocId -> m Reply
 indexDocument (IndexName indexName) cfg document (DocId docId) =
-  bindM2 put url (return body)
+  bindM2 post url (return body)
   where url = addQuery params <$> joinPath [indexName, "_create", docId]
         parentParams = case idsParent cfg of
           Nothing -> []

--- a/tests/Test/Aggregation.hs
+++ b/tests/Test/Aggregation.hs
@@ -97,8 +97,8 @@ spec =
       let ltAWeekAgo = UTCTime (fromGregorian 2015 3 10) 0
       let oldDoc = exampleTweet { postDate = ltAMonthAgo }
       let newDoc = exampleTweet { postDate = ltAWeekAgo }
-      _ <- indexDocument testIndex testMapping defaultIndexDocumentSettings oldDoc (DocId "1")
-      _ <- indexDocument testIndex testMapping defaultIndexDocumentSettings newDoc (DocId "2")
+      _ <- indexDocument testIndex defaultIndexDocumentSettings oldDoc (DocId "1")
+      _ <- indexDocument testIndex defaultIndexDocumentSettings newDoc (DocId "2")
       _ <- refreshIndex testIndex
       let thisMonth = DateRangeFrom (DateMathExpr (DMDate now) [SubtractTime 1 DMMonth])
       let thisWeek = DateRangeFrom (DateMathExpr (DMDate now) [SubtractTime 1 DMWeek])

--- a/tests/Test/Common.hs
+++ b/tests/Test/Common.hs
@@ -191,7 +191,7 @@ insertData = do
 
 insertData' :: IndexDocumentSettings -> BH IO Reply
 insertData' ids = do
-  r <- indexDocument testIndex testMapping ids exampleTweet (DocId "1")
+  r <- indexDocument testIndex ids exampleTweet (DocId "1")
   _ <- refreshIndex testIndex
   return r
 
@@ -203,19 +203,19 @@ updateData = do
 
 insertOther :: BH IO ()
 insertOther = do
-  _ <- indexDocument testIndex testMapping defaultIndexDocumentSettings otherTweet (DocId "2")
+  _ <- indexDocument testIndex defaultIndexDocumentSettings otherTweet (DocId "2")
   _ <- refreshIndex testIndex
   return ()
 
 insertExtra :: BH IO ()
 insertExtra = do
-  _ <- indexDocument testIndex testMapping defaultIndexDocumentSettings tweetWithExtra (DocId "4")
+  _ <- indexDocument testIndex defaultIndexDocumentSettings tweetWithExtra (DocId "4")
   _ <- refreshIndex testIndex
   return ()
 
 insertWithSpaceInId :: BH IO ()
 insertWithSpaceInId = do
-  _ <- indexDocument testIndex testMapping defaultIndexDocumentSettings exampleTweet (DocId "Hello World")
+  _ <- indexDocument testIndex defaultIndexDocumentSettings exampleTweet (DocId "Hello World")
   _ <- refreshIndex testIndex
   return ()
 

--- a/tests/Test/Documents.hs
+++ b/tests/Test/Documents.hs
@@ -42,10 +42,10 @@ spec =
       resetIndex
       _ <- putMapping testIndex (MappingName "child") ChildMapping
       _ <- putMapping testIndex (MappingName "parent") ParentMapping
-      _ <- indexDocument testIndex (MappingName "parent") defaultIndexDocumentSettings exampleTweet (DocId "1")
+      _ <- indexDocument testIndex defaultIndexDocumentSettings exampleTweet (DocId "1")
       let parent = (Just . DocumentParent . DocId) "1"
           ids = IndexDocumentSettings NoVersionControl parent
-      _ <- indexDocument testIndex (MappingName "child") ids otherTweet (DocId "2")
+      _ <- indexDocument testIndex ids otherTweet (DocId "2")
       _ <- refreshIndex testIndex
       exists <- documentExists testIndex (MappingName "child") parent (DocId "2")
       liftIO $ exists `shouldBe` True


### PR DESCRIPTION
According to https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html, mapping names/types are being removed from Elasticsearch.  I am running Elasticsearch 7.3 which rejects requests made with the current implementation of e.g. `indexDocument`:

```
Response {
  responseStatus = Status {statusCode = 400, statusMessage = "Bad Request"}, 
  responseVersion = HTTP/1.1, 
  responseHeaders = [
    ("Warning","299 Elasticsearch-7.3.0-de777fa \"[types removal] Specifying types in document index requests is deprecated, use the typeless endpoints instead (/{index}/_doc/{id}, /{index}/_doc, or /{index}/_create/{id}).\""),
    ("content-type","application/json; charset=UTF-8"),
    ("content-encoding","gzip"),
    ("content-length","183")], 
  responseBody = "{\"error\":{\"root_cause\":[{\"type\":\"illegal_argument_exception\",\"reason\":\"Rejecting mapping update to [index-name] as the final mapping would have more than 1 type: [_doc, mapping-name]\"}],\"type\":\"illegal_argument_exception\",\"reason\":\"Rejecting mapping update to [index-name] as the final mapping would have more than 1 type: [_doc, mapping-name]\"},\"status\":400}", 
  responseCookieJar = CJ {expose = []}, 
  responseClose' = ResponseClose}
```

Furthermore, Elasticsearch seems to expect `POST` requests instead of a `PUT` requests now.

This PR changes `indexDocument` so that it works with the current version of Elasticsearch. If this is a welcome change, I can look into updating the other parts of the library.