### PR TITLE
Add 'BulkUpsert' operation (now with tests)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 - @JoseD92
   - Removed the disused `Seminearring` class.
   - Added Docker Compose support.
+- @Kheldar, @AlexeyRaga, @dsturnbull
+  - Added support for BulkUpsert operations that allow for additional metadata.
 
 0.16.0.0
 ========

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -52,6 +52,7 @@ module Database.Bloodhound.Client
        , getDocument
        , documentExists
        , deleteDocument
+       , deleteByQuery
        -- ** Searching
        , searchAll
        , searchByIndex
@@ -862,6 +863,17 @@ deleteDocument :: MonadBH m => IndexName -> MappingName
 deleteDocument (IndexName indexName)
   (MappingName mappingName) (DocId docId) =
   delete =<< joinPath [indexName, mappingName, docId]
+
+-- | 'deleteByQuery' performs a deletion on every document that matches a query.
+--
+-- >>> let query = TermQuery (Term "user" "bitemyapp") Nothing
+-- >>> _ <- runBH' $ deleteDocument testIndex testMapping query
+deleteByQuery :: MonadBH m => IndexName -> MappingName -> Query -> m Reply
+deleteByQuery (IndexName indexName) (MappingName mappingName) query =
+  bindM2 post url (return body)
+  where
+    url = joinPath [indexName, mappingName, "_delete_by_query"]
+    body = Just (encode $ object [ "query" .= query ])
 
 -- | 'bulk' uses
 --    <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html Elasticsearch's bulk API>

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -411,7 +411,7 @@ getSnapshots (SnapshotRepoName repoName) sel =
   where
     url = joinPath ["_snapshot", repoName, snapPath]
     snapPath = case sel of
-      AllSnapshots           -> "_all"
+      AllSnapshots -> "_all"
       SnapshotList (s :| ss) -> T.intercalate "," (renderPath <$> (s:ss))
     renderPath (SnapPattern t)              = t
     renderPath (ExactSnap (SnapshotName t)) = t
@@ -479,9 +479,9 @@ getNodesInfo sel = parseEsResponse =<< get =<< url
   where
     url = joinPath ["_nodes", selectionSeg]
     selectionSeg = case sel of
-      LocalNode          -> "_local"
+      LocalNode -> "_local"
       NodeList (l :| ls) -> T.intercalate "," (selToSeg <$> (l:ls))
-      AllNodes           -> "_all"
+      AllNodes -> "_all"
     selToSeg (NodeByName (NodeName n))            = n
     selToSeg (NodeByFullNodeId (FullNodeId i))    = i
     selToSeg (NodeByHost (Server s))              = s
@@ -497,9 +497,9 @@ getNodesStats sel = parseEsResponse =<< get =<< url
   where
     url = joinPath ["_nodes", selectionSeg, "stats"]
     selectionSeg = case sel of
-      LocalNode          -> "_local"
+      LocalNode -> "_local"
       NodeList (l :| ls) -> T.intercalate "," (selToSeg <$> (l:ls))
-      AllNodes           -> "_all"
+      AllNodes -> "_all"
     selToSeg (NodeByName (NodeName n))            = n
     selToSeg (NodeByFullNodeId (FullNodeId i))    = i
     selToSeg (NodeByHost (Server s))              = s
@@ -620,7 +620,7 @@ deepMerge = LS.foldl' go mempty
   where go acc = LS.foldl' go' acc . HM.toList
         go' acc (k, v) = HM.insertWith merge k v acc
         merge (Object a) (Object b) = Object (deepMerge [a, b])
-        merge _ b                   = b
+        merge _ b = b
 
 
 statusCodeIs :: (Int, Int) -> Reply -> Bool
@@ -827,10 +827,10 @@ putMapping (IndexName indexName) (MappingName mappingName) mapping =
 versionCtlParams :: IndexDocumentSettings -> [(Text, Maybe Text)]
 versionCtlParams cfg =
   case idsVersionControl cfg of
-    NoVersionControl                    -> []
-    InternalVersion v                   -> versionParams v "internal"
-    ExternalGT (ExternalDocVersion v)   -> versionParams v "external_gt"
-    ExternalGTE (ExternalDocVersion v)  -> versionParams v "external_gte"
+    NoVersionControl -> []
+    InternalVersion v -> versionParams v "internal"
+    ExternalGT (ExternalDocVersion v) -> versionParams v "external_gt"
+    ExternalGTE (ExternalDocVersion v) -> versionParams v "external_gte"
     ForceVersion (ExternalDocVersion v) -> versionParams v "force"
   where
     vt = showText . docVersionNumber
@@ -856,7 +856,7 @@ indexDocument (IndexName indexName)
   bindM2 put url (return body)
   where url = addQuery params <$> joinPath [indexName, mappingName, docId]
         parentParams = case idsParent cfg of
-          Nothing                         -> []
+          Nothing -> []
           Just (DocumentParent (DocId p)) -> [ ("parent", Just p) ]
         params = versionCtlParams cfg ++ parentParams
         body = Just (encode document)
@@ -1126,7 +1126,7 @@ scroll' (Just sid) = do
     res <- advanceScroll sid 60
     case res of
       Right SearchResult {..} -> return (hits searchHits, scrollId)
-      Left _                  -> return ([], Nothing)
+      Left _ -> return ([], Nothing)
 
 -- | Use the given scroll to fetch the next page of documents. If there are no
 -- further pages, 'SearchResult.searchHits.hits' will be '[]'.

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -411,7 +411,7 @@ getSnapshots (SnapshotRepoName repoName) sel =
   where
     url = joinPath ["_snapshot", repoName, snapPath]
     snapPath = case sel of
-      AllSnapshots -> "_all"
+      AllSnapshots           -> "_all"
       SnapshotList (s :| ss) -> T.intercalate "," (renderPath <$> (s:ss))
     renderPath (SnapPattern t)              = t
     renderPath (ExactSnap (SnapshotName t)) = t
@@ -479,9 +479,9 @@ getNodesInfo sel = parseEsResponse =<< get =<< url
   where
     url = joinPath ["_nodes", selectionSeg]
     selectionSeg = case sel of
-      LocalNode -> "_local"
+      LocalNode          -> "_local"
       NodeList (l :| ls) -> T.intercalate "," (selToSeg <$> (l:ls))
-      AllNodes -> "_all"
+      AllNodes           -> "_all"
     selToSeg (NodeByName (NodeName n))            = n
     selToSeg (NodeByFullNodeId (FullNodeId i))    = i
     selToSeg (NodeByHost (Server s))              = s
@@ -497,9 +497,9 @@ getNodesStats sel = parseEsResponse =<< get =<< url
   where
     url = joinPath ["_nodes", selectionSeg, "stats"]
     selectionSeg = case sel of
-      LocalNode -> "_local"
+      LocalNode          -> "_local"
       NodeList (l :| ls) -> T.intercalate "," (selToSeg <$> (l:ls))
-      AllNodes -> "_all"
+      AllNodes           -> "_all"
     selToSeg (NodeByName (NodeName n))            = n
     selToSeg (NodeByFullNodeId (FullNodeId i))    = i
     selToSeg (NodeByHost (Server s))              = s
@@ -620,7 +620,7 @@ deepMerge = LS.foldl' go mempty
   where go acc = LS.foldl' go' acc . HM.toList
         go' acc (k, v) = HM.insertWith merge k v acc
         merge (Object a) (Object b) = Object (deepMerge [a, b])
-        merge _ b = b
+        merge _ b                   = b
 
 
 statusCodeIs :: (Int, Int) -> Reply -> Bool
@@ -827,10 +827,10 @@ putMapping (IndexName indexName) (MappingName mappingName) mapping =
 versionCtlParams :: IndexDocumentSettings -> [(Text, Maybe Text)]
 versionCtlParams cfg =
   case idsVersionControl cfg of
-    NoVersionControl -> []
-    InternalVersion v -> versionParams v "internal"
-    ExternalGT (ExternalDocVersion v) -> versionParams v "external_gt"
-    ExternalGTE (ExternalDocVersion v) -> versionParams v "external_gte"
+    NoVersionControl                    -> []
+    InternalVersion v                   -> versionParams v "internal"
+    ExternalGT (ExternalDocVersion v)   -> versionParams v "external_gt"
+    ExternalGTE (ExternalDocVersion v)  -> versionParams v "external_gte"
     ForceVersion (ExternalDocVersion v) -> versionParams v "force"
   where
     vt = showText . docVersionNumber
@@ -856,7 +856,7 @@ indexDocument (IndexName indexName)
   bindM2 put url (return body)
   where url = addQuery params <$> joinPath [indexName, mappingName, docId]
         parentParams = case idsParent cfg of
-          Nothing -> []
+          Nothing                         -> []
           Just (DocumentParent (DocId p)) -> [ ("parent", Just p) ]
         params = versionCtlParams cfg ++ parentParams
         body = Just (encode document)
@@ -995,12 +995,21 @@ encodeBulkOperation (BulkUpdate (IndexName indexName)
 encodeBulkOperation (BulkUpsert (IndexName indexName)
                 (MappingName mappingName)
                 (DocId docId)
-                value
-                actionMeta
-                docMeta) = blob
+                payload
+                actionMeta) = blob
     where metadata = mkBulkStreamValueWithMeta actionMeta "update" indexName mappingName docId
-          doc = object $ ["doc" .= value] <> (buildUpsertPayloadMetadata <$> docMeta)
           blob = encode metadata <> "\n" <> encode doc
+          doc = case payload of
+            UpsertDoc value -> object ["doc" .= value, "doc_as_upsert" .= True]
+            UpsertScript scriptedUpsert script value ->
+              let scup = if scriptedUpsert then ["scripted_upsert" .= True] else []
+                  upsert = ["upsert" .= value]
+              in
+                case (object (scup <> upsert), toJSON script) of
+                  (Object obj, Object jscript) -> Object $ jscript <> obj
+                  _ -> error "Impossible happened: serialising Script to Json should always be Object"
+
+
 
 encodeBulkOperation (BulkCreateEncoding (IndexName indexName)
                 (MappingName mappingName)
@@ -1117,7 +1126,7 @@ scroll' (Just sid) = do
     res <- advanceScroll sid 60
     case res of
       Right SearchResult {..} -> return (hits searchHits, scrollId)
-      Left _ -> return ([], Nothing)
+      Left _                  -> return ([], Nothing)
 
 -- | Use the given scroll to fetch the next page of documents. If there are no
 -- further pages, 'SearchResult.searchHits.hits' will be '[]'.

--- a/src/Database/Bloodhound/Internal/Client.hs
+++ b/src/Database/Bloodhound/Internal/Client.hs
@@ -592,6 +592,34 @@ data Mapping =
           , mappingFields :: [MappingField] }
   deriving (Eq, Show)
 
+data UpsertActionMetadata
+  = UA_RetryOnConflict Int
+  | UA_Source Bool
+  | UA_Version Int
+  deriving (Eq, Show)
+
+buildUpsertActionMetadata :: UpsertActionMetadata -> Pair
+buildUpsertActionMetadata (UA_RetryOnConflict i) = "_retry_on_conflict" .= i
+buildUpsertActionMetadata (UA_Source b)          = "_source"            .= b
+buildUpsertActionMetadata (UA_Version i)         = "_version"           .= i
+
+data UpsertPayloadMetadata
+  = UP_DocAsUpsert Bool
+  | UP_Script Value
+  | UP_Lang Text
+  | UP_Params Value
+  | UP_Upsert Value
+  | UP_Source Bool
+  deriving (Eq, Show)
+
+buildUpsertPayloadMetadata :: UpsertPayloadMetadata -> Pair
+buildUpsertPayloadMetadata (UP_DocAsUpsert a) = "doc_as_upsert" .= a
+buildUpsertPayloadMetadata (UP_Script a)      = "script"        .= a
+buildUpsertPayloadMetadata (UP_Lang a)        = "lang"          .= a
+buildUpsertPayloadMetadata (UP_Params a)      = "params"        .= a
+buildUpsertPayloadMetadata (UP_Upsert a)      = "upsert"        .= a
+buildUpsertPayloadMetadata (UP_Source a)      = "_source"       .= a
+
 data AllocationPolicy = AllocAll
                       -- ^ Allows shard allocation for all shards.
                       | AllocPrimaries
@@ -644,6 +672,8 @@ data BulkOperation =
     -- ^ Delete the document
   | BulkUpdate IndexName MappingName DocId Value
     -- ^ Update the document, merging the new value with the existing one.
+  | BulkUpsert IndexName MappingName DocId Value [UpsertActionMetadata] [UpsertPayloadMetadata]
+    -- ^ Update the document if it already exists, otherwise insert it.
     deriving (Eq, Show)
 
 {-| 'EsResult' describes the standard wrapper JSON document that you see in

--- a/src/Database/Bloodhound/Internal/Client.hs
+++ b/src/Database/Bloodhound/Internal/Client.hs
@@ -599,7 +599,7 @@ data UpsertActionMetadata
   deriving (Eq, Show)
 
 buildUpsertActionMetadata :: UpsertActionMetadata -> Pair
-buildUpsertActionMetadata (UA_RetryOnConflict i) = "_retry_on_conflict" .= i
+buildUpsertActionMetadata (UA_RetryOnConflict i) = "retry_on_conflict"  .= i
 buildUpsertActionMetadata (UA_Source b)          = "_source"            .= b
 buildUpsertActionMetadata (UA_Version i)         = "_version"           .= i
 
@@ -2458,4 +2458,4 @@ instance FromJSON VersionNumber where
       parse t =
         case SemVer.fromText t of
           (Left err) -> fail err
-          (Right v) -> return (VersionNumber v)
+          (Right v)  -> return (VersionNumber v)

--- a/src/Database/Bloodhound/Internal/Client.hs
+++ b/src/Database/Bloodhound/Internal/Client.hs
@@ -12,18 +12,18 @@ import           Bloodhound.Import
 
 #if defined(MIN_VERSION_GLASGOW_HASKELL)
 #if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
-import Control.Monad.Fail (MonadFail)
+import           Control.Monad.Fail                         (MonadFail)
 #endif
 #endif
-import qualified Data.Text           as T
-import qualified Data.Traversable    as DT
-import qualified Data.HashMap.Strict as HM
-import qualified Data.SemVer         as SemVer
-import qualified Data.Vector         as V
+import qualified Data.HashMap.Strict                        as HM
+import qualified Data.SemVer                                as SemVer
+import qualified Data.Text                                  as T
+import qualified Data.Traversable                           as DT
+import qualified Data.Vector                                as V
 import           GHC.Enum
 import           Network.HTTP.Client
-import           Text.Read           (Read(..))
-import qualified Text.Read           as TR
+import           Text.Read                                  (Read (..))
+import qualified Text.Read                                  as TR
 
 import           Database.Bloodhound.Internal.Analysis
 import           Database.Bloodhound.Internal.Newtypes
@@ -398,13 +398,13 @@ data Compression
 instance ToJSON Compression where
   toJSON x = case x of
     CompressionDefault -> toJSON ("default" :: Text)
-    CompressionBest -> toJSON ("best_compression" :: Text)
+    CompressionBest    -> toJSON ("best_compression" :: Text)
 
 instance FromJSON Compression where
   parseJSON = withText "Compression" $ \t -> case t of
-    "default" -> return CompressionDefault
+    "default"          -> return CompressionDefault
     "best_compression" -> return CompressionBest
-    _ -> fail "invalid compression codec"
+    _                  -> fail "invalid compression codec"
 
 -- | A measure of bytes used for various configurations. You may want
 -- to use smart constructors like 'gigabytes' for larger values.
@@ -594,31 +594,17 @@ data Mapping =
 
 data UpsertActionMetadata
   = UA_RetryOnConflict Int
-  | UA_Source Bool
   | UA_Version Int
   deriving (Eq, Show)
 
 buildUpsertActionMetadata :: UpsertActionMetadata -> Pair
 buildUpsertActionMetadata (UA_RetryOnConflict i) = "retry_on_conflict"  .= i
-buildUpsertActionMetadata (UA_Source b)          = "_source"            .= b
 buildUpsertActionMetadata (UA_Version i)         = "_version"           .= i
 
-data UpsertPayloadMetadata
-  = UP_DocAsUpsert Bool
-  | UP_Script Value
-  | UP_Lang Text
-  | UP_Params Value
-  | UP_Upsert Value
-  | UP_Source Bool
+data UpsertPayload
+  = UpsertDoc Value
+  | UpsertScript Bool Script Value
   deriving (Eq, Show)
-
-buildUpsertPayloadMetadata :: UpsertPayloadMetadata -> Pair
-buildUpsertPayloadMetadata (UP_DocAsUpsert a) = "doc_as_upsert" .= a
-buildUpsertPayloadMetadata (UP_Script a)      = "script"        .= a
-buildUpsertPayloadMetadata (UP_Lang a)        = "lang"          .= a
-buildUpsertPayloadMetadata (UP_Params a)      = "params"        .= a
-buildUpsertPayloadMetadata (UP_Upsert a)      = "upsert"        .= a
-buildUpsertPayloadMetadata (UP_Source a)      = "_source"       .= a
 
 data AllocationPolicy = AllocAll
                       -- ^ Allows shard allocation for all shards.
@@ -672,7 +658,7 @@ data BulkOperation =
     -- ^ Delete the document
   | BulkUpdate IndexName MappingName DocId Value
     -- ^ Update the document, merging the new value with the existing one.
-  | BulkUpsert IndexName MappingName DocId Value [UpsertActionMetadata] [UpsertPayloadMetadata]
+  | BulkUpsert IndexName MappingName DocId UpsertPayload [UpsertActionMetadata]
     -- ^ Update the document if it already exists, otherwise insert it.
     deriving (Eq, Show)
 
@@ -735,7 +721,7 @@ and be sure to include the exception body.
 -}
 data EsProtocolException = EsProtocolException
   { esProtoExMessage :: !Text
-  , esProtoExBody :: !LByteString
+  , esProtoExBody    :: !LByteString
   } deriving (Eq, Show)
 
 instance Exception EsProtocolException

--- a/src/Database/Bloodhound/Internal/Client.hs
+++ b/src/Database/Bloodhound/Internal/Client.hs
@@ -398,13 +398,13 @@ data Compression
 instance ToJSON Compression where
   toJSON x = case x of
     CompressionDefault -> toJSON ("default" :: Text)
-    CompressionBest    -> toJSON ("best_compression" :: Text)
+    CompressionBest -> toJSON ("best_compression" :: Text)
 
 instance FromJSON Compression where
   parseJSON = withText "Compression" $ \t -> case t of
-    "default"          -> return CompressionDefault
+    "default" -> return CompressionDefault
     "best_compression" -> return CompressionBest
-    _                  -> fail "invalid compression codec"
+    _ -> fail "invalid compression codec"
 
 -- | A measure of bytes used for various configurations. You may want
 -- to use smart constructors like 'gigabytes' for larger values.
@@ -721,7 +721,7 @@ and be sure to include the exception body.
 -}
 data EsProtocolException = EsProtocolException
   { esProtoExMessage :: !Text
-  , esProtoExBody    :: !LByteString
+  , esProtoExBody :: !LByteString
   } deriving (Eq, Show)
 
 instance Exception EsProtocolException
@@ -2444,4 +2444,4 @@ instance FromJSON VersionNumber where
       parse t =
         case SemVer.fromText t of
           (Left err) -> fail err
-          (Right v)  -> return (VersionNumber v)
+          (Right v) -> return (VersionNumber v)

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -255,6 +255,10 @@ module Database.Bloodhound.Types
        , FieldDefinition(..)
        , MappingField(..)
        , Mapping(..)
+       , UpsertActionMetadata(..)
+       , buildUpsertActionMetadata
+       , UpsertPayloadMetadata(..)
+       , buildUpsertPayloadMetadata
        , AllowLeadingWildcard(..)
        , LowercaseExpanded(..)
        , GeneratePhraseQueries(..)

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -257,8 +257,7 @@ module Database.Bloodhound.Types
        , Mapping(..)
        , UpsertActionMetadata(..)
        , buildUpsertActionMetadata
-       , UpsertPayloadMetadata(..)
-       , buildUpsertPayloadMetadata
+       , UpsertPayload(..)
        , AllowLeadingWildcard(..)
        , LowercaseExpanded(..)
        , GeneratePhraseQueries(..)

--- a/tests/Test/BulkAPI.hs
+++ b/tests/Test/BulkAPI.hs
@@ -2,11 +2,15 @@
 
 module Test.BulkAPI (spec) where
 
-import Test.Common
-import Test.Import
+import           Data.Function       ((&))
+import           Data.Functor        ((<&>))
 
-import qualified Data.Vector as V
-import qualified Lens.Micro.Aeson as LMA
+import           Test.Common
+import           Test.Import
+
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Vector         as V
+import qualified Lens.Micro.Aeson    as LMA
 
 newtype BulkTest =
   BulkTest Text
@@ -23,9 +27,104 @@ instance FromJSON BulkTest where
         t <- o .: "name"
         BulkTest <$> parseJSON t
 
+data BulkScriptTest = BulkScriptTest
+  { bstName    :: Text
+  , bstCounter :: Int
+  }
+  deriving (Eq, Show)
+
+instance ToJSON BulkScriptTest where
+  toJSON (BulkScriptTest name' count) =
+    object ["name" .= name', "counter" .= count]
+
+instance FromJSON BulkScriptTest where
+  parseJSON = withObject "BulkScriptTest" $ \v -> BulkScriptTest
+    <$> v.: "name"
+    <*> v .: "counter"
+
+assertDocs :: (FromJSON a, Show a, Eq a) => [(DocId, a)] -> BH IO ()
+assertDocs as = do
+  let (ids, docs) = unzip as
+  res <- ids &   traverse (getDocument testIndex testMapping)
+             <&> traverse (fmap getSource . eitherDecode . responseBody)
+
+  liftIO $ res `shouldBe` Right (Just <$> docs)
+
+upsertDocs :: (ToJSON a, Show a, Eq a)
+  => (Value -> UpsertPayload)
+  -> [(DocId, a)]
+  -> BH IO ()
+upsertDocs f as = do
+  let batch = as <&> (\(id_, doc) -> BulkUpsert testIndex testMapping id_ (f $ toJSON doc) []) & V.fromList
+  bulk batch >> refreshIndex testIndex >> pure ()
+
 spec :: Spec
 spec =
-  describe "Bulk API" $
+  describe "Bulk API" $ do
+    it "upsert operations" $ withTestEnv $ do
+      _ <- insertData
+
+      -- Upserting in a to a fresh index should insert
+      let toInsert = [(DocId "3", BulkTest "stringer"), (DocId "5", BulkTest "sobotka"), (DocId "7", BulkTest "snoop")]
+      upsertDocs UpsertDoc toInsert
+      assertDocs toInsert
+
+      -- Upserting existing documents should update
+      let toUpsert = [(DocId "3", BulkTest "bell"), (DocId "5", BulkTest "frank"), (DocId "7", BulkTest "snoop")]
+      upsertDocs UpsertDoc toUpsert
+      assertDocs toUpsert
+
+    it "upsert with a script" $ withTestEnv $ do
+      _ <- insertData
+
+      -- first insert the batch
+      let batch = [(DocId "3", BulkScriptTest "stringer" 0), (DocId "5", BulkScriptTest "sobotka" 3)]
+      upsertDocs UpsertDoc batch
+
+      -- then upsert with the script
+
+      let script = Script
+                    { scriptLanguage = Just $ ScriptLanguage "painless"
+                    , scriptInline = Just $ ScriptInline "ctx._source.counter += params.count"
+                    , scriptStored = Nothing
+                    , scriptParams = Just $ ScriptParams $ HM.fromList [("count", Number 2)]
+                    }
+
+      upsertDocs (UpsertScript False script) batch
+      assertDocs (batch <&> (\(i, v) -> (i, v { bstCounter = bstCounter v + 2 })))
+
+    it "script upsert without scripted_upsert" $ withTestEnv $ do
+      _ <- insertData
+
+      let batch = [(DocId "3", BulkScriptTest "stringer" 0), (DocId "5", BulkScriptTest "sobotka" 3)]
+
+      let script = Script
+                    { scriptLanguage = Just $ ScriptLanguage "painless"
+                    , scriptInline = Just $ ScriptInline "ctx._source.counter += params.count"
+                    , scriptStored = Nothing
+                    , scriptParams = Just $ ScriptParams $ HM.fromList [("count", Number 2)]
+                    }
+
+      -- Without "script_upsert" flag new documents are simply inserted and are not handled by the script
+      upsertDocs (UpsertScript False script) batch
+      assertDocs batch
+
+    it "script upsert with scripted_upsert" $ withTestEnv $ do
+      _ <- insertData
+
+      let batch = [(DocId "3", BulkScriptTest "stringer" 0), (DocId "5", BulkScriptTest "sobotka" 3)]
+
+      let script = Script
+                    { scriptLanguage = Just $ ScriptLanguage "painless"
+                    , scriptInline = Just $ ScriptInline "ctx._source.counter += params.count"
+                    , scriptStored = Nothing
+                    , scriptParams = Just $ ScriptParams $ HM.fromList [("count", Number 2)]
+                    }
+
+      -- Without "script_upsert" flag new documents are simply inserted and are not handled by the script
+      upsertDocs (UpsertScript True script) batch
+      assertDocs (batch <&> (\(i, v) -> (i, v { bstCounter = bstCounter v + 2 })))
+
     it "inserts all documents we request" $ withTestEnv $ do
       _ <- insertData
       let firstTest = BulkTest "blah"


### PR DESCRIPTION
Supercedes #250 

This adds an extra `Bulk` operation, with upsert semantics and the ability to pass some extra metadata that isn't possible with the existing API.

We've also added some tests for it, so hopefully it should be maintainable :) 