### PR TITLE
Support GHC 8.8 for 0.16.0.0

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -1,5 +1,5 @@
 name:                bloodhound
-version:             0.16.0.0
+version:             0.16.0.1
 synopsis:            Elasticsearch client library for Haskell
 description:         Elasticsearch made awesome for Haskell hackers
 homepage:            https://github.com/bitemyapp/bloodhound
@@ -67,18 +67,18 @@ library
                        aeson            >= 0.11.1,
                        blaze-builder,
                        bytestring       >= 0.10.0  && <0.11,
-                       containers       >= 0.5.0.0 && <0.6,
+                       containers       >= 0.5.0.0 && <0.7,
                        exceptions,
                        hashable,
-                       http-client      >= 0.4.30  && <0.6,
+                       http-client      >= 0.4.30  && <0.7,
                        http-types       >= 0.8     && <0.13,
                        mtl              >= 1.0     && <2.3,
                        network-uri      >= 2.6     && <2.7,
                        scientific       >= 0.3.0.0 && <0.4.0.0,
-                       semigroups       >= 0.15    && <0.19,
+                       semigroups       >= 0.15    && <0.20,
                        semver,
                        text             >= 0.11    && <1.3,
-                       time             >= 1.4     && <1.9,
+                       time             >= 1.4     && <2.0,
                        transformers     >= 0.2     && <0.6,
                        unordered-containers,
                        vector           >= 0.10.9  && <0.13

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+allow-newer: quickcheck-arbitrary-template:template-haskell

--- a/src/Database/V1/Bloodhound/Internal/Client.hs
+++ b/src/Database/V1/Bloodhound/Internal/Client.hs
@@ -7,8 +7,10 @@
 
 module Database.V1.Bloodhound.Internal.Client where
 
+import           Prelude                                       hiding (fail)
 import           Bloodhound.Import
 
+import           Control.Monad.Fail (MonadFail(..))
 import           Control.Applicative                           as A
 import qualified Data.HashMap.Strict                           as HM
 import           Data.Text                                     (Text)
@@ -1552,7 +1554,7 @@ instance ToJSON Interval where
   toJSON Second = "second"
   toJSON (FractionalInterval fraction interval) = toJSON $ show fraction ++ show interval
 
-parseStringInterval :: (Monad m) => String -> m NominalDiffTime
+parseStringInterval :: (Monad m, MonadFail m) => String -> m NominalDiffTime
 parseStringInterval s = case span isNumber s of
   ("", _) -> fail "Invalid interval"
   (nS, unitS) -> case (readMay nS, readMay unitS) of

--- a/src/Database/V1/Bloodhound/Internal/Query.hs
+++ b/src/Database/V1/Bloodhound/Internal/Query.hs
@@ -5,8 +5,10 @@
 module Database.V1.Bloodhound.Internal.Query where
 
 
+import           Prelude                                  hiding (fail)
 import           Bloodhound.Import
 
+import           Control.Monad.Fail (MonadFail(..))
 import qualified Data.HashMap.Strict                      as HM
 import qualified Data.Text                                as T
 
@@ -1468,7 +1470,7 @@ instance FromJSON ZeroTermsQuery where
           parse "all"  = pure ZeroTermsAll
           parse q      = fail ("Unexpected ZeroTermsQuery: " <> show q)
 
-fieldTagged :: Monad m => (FieldName -> Object -> m a) -> Object -> m a
+fieldTagged :: (Monad m, MonadFail m) => (FieldName -> Object -> m a) -> Object -> m a
 fieldTagged f o = case HM.toList o of
                     [(k, Object o')] -> f (FieldName k) o'
                     _ -> fail "Expected object with 1 field-named key"

--- a/src/Database/V5/Bloodhound/Internal/Client.hs
+++ b/src/Database/V5/Bloodhound/Internal/Client.hs
@@ -7,8 +7,10 @@
 
 module Database.V5.Bloodhound.Internal.Client where
 
+import           Prelude             hiding (fail)
 import           Bloodhound.Import
 
+import           Control.Monad.Fail (MonadFail(..))
 import qualified Data.Text           as T
 import qualified Data.Traversable    as DT
 import qualified Data.HashMap.Strict as HM
@@ -2331,7 +2333,7 @@ instance ToJSON Interval where
   toJSON Minute  = "minute"
   toJSON Second  = "second"
 
-parseStringInterval :: (Monad m) => String -> m NominalDiffTime
+parseStringInterval :: (Monad m, MonadFail m) => String -> m NominalDiffTime
 parseStringInterval s = case span isNumber s of
   ("", _) -> fail "Invalid interval"
   (nS, unitS) -> case (readMay nS, readMay unitS) of

--- a/src/Database/V5/Bloodhound/Internal/Query.hs
+++ b/src/Database/V5/Bloodhound/Internal/Query.hs
@@ -7,8 +7,10 @@ module Database.V5.Bloodhound.Internal.Query
   , module Database.V5.Bloodhound.Internal.Query
   ) where
 
+import           Prelude             hiding (fail)
 import           Bloodhound.Import
 
+import           Control.Monad.Fail  (MonadFail(..))
 import           Data.Char           (isNumber)
 import qualified Data.HashMap.Strict as HM
 import           Data.List           (nub)
@@ -1617,7 +1619,7 @@ functionScoreFunctionsPair (FunctionScoreSingle fn)
 functionScoreFunctionsPair (FunctionScoreMultiple componentFns) =
   ("functions", toJSON componentFns)
 
-fieldTagged :: Monad m => (FieldName -> Object -> m a) -> Object -> m a
+fieldTagged :: (Monad m, MonadFail m) => (FieldName -> Object -> m a) -> Object -> m a
 fieldTagged f o = case HM.toList o of
                     [(k, Object o')] -> f (FieldName k) o'
                     _ -> fail "Expected object with 1 field-named key"

--- a/tests/V5/Test/Generators.hs
+++ b/tests/V5/Test/Generators.hs
@@ -183,7 +183,7 @@ instance Arbitrary Query where
 
 instance Arbitrary Filter where
   arbitrary =
-    Filter <$> arbitrary 
+    Filter <$> arbitrary
   shrink (Filter q) =
     Filter <$> shrink q
 
@@ -210,9 +210,12 @@ instance Arbitrary NodeAttrName where
 instance Arbitrary NodeAttrFilter where
   arbitrary = do
     n <- arbitrary
-    s:ss <- listOf1 (listOf1 arbitraryAlphaNum)
-    let ts = T.pack <$> s :| ss
-    return (NodeAttrFilter n ts)
+    xs <- listOf1 (listOf1 arbitraryAlphaNum)
+    case xs of
+      [] -> error "Failed to generate non-empty list of arbitraryAlphaNum"
+      (s:ss) ->
+        let ts = T.pack <$> s :| ss
+        in return (NodeAttrFilter n ts)
 
 instance Arbitrary VersionNumber where
   arbitrary = do

--- a/tests/V5/Test/Import.hs
+++ b/tests/V5/Test/Import.hs
@@ -31,7 +31,7 @@ import System.IO.Temp as X
 import System.PosixCompat.Files as X
 import Test.Hspec as X
 import Test.Hspec.QuickCheck as X (prop)
-import Test.QuickCheck as X hiding (Result, Success)
+import Test.QuickCheck as X hiding (Result, Success, isSuccess)
 import Test.QuickCheck.Property.Monoid as X (T (..), eq, prop_Monoid)
 import Text.Pretty.Simple as X (pPrint)
 


### PR DESCRIPTION
While waiting for the next major release of Bloodhound, we'd like to use the current released version (0.16.0.0) with GHC 8.8 and 8.10 support. I'd appreciate if you can do a minor release 0.16.0.1 to make life easier for current users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitemyapp/bloodhound/269)
<!-- Reviewable:end -->
