### PR TITLE
Fix deleteDocument endpoint

### DIFF
--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -913,7 +913,7 @@ encodeDocument cfg document =
 -- >>> _ <- runBH' $ deleteDocument testIndex (DocId "1")
 deleteDocument :: MonadBH m => IndexName -> DocId -> m Reply
 deleteDocument (IndexName indexName) (DocId docId) =
-  delete =<< joinPath [indexName, docId]
+  delete =<< joinPath [indexName, "_doc", docId]
 
 -- | 'deleteByQuery' performs a deletion on every document that matches a query.
 --


### PR DESCRIPTION
It occurs that the endpoint called lacked the `"_doc"` part: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html