### PR TITLE
Point in time (PIT) API support

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -44,6 +44,7 @@ library
       Bloodhound.Import
       Database.Bloodhound.Common.Script
       Database.Bloodhound.Internal.Count
+      Database.Bloodhound.Internal.PointInTime
       Paths_bloodhound
   hs-source-dirs:
       src

--- a/src/Database/Bloodhound/Internal/PointInTime.hs
+++ b/src/Database/Bloodhound/Internal/PointInTime.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE OverloadedStrings          #-}
+
+module Database.Bloodhound.Internal.PointInTime where
+
+import           Bloodhound.Import
+
+data PointInTime = PointInTime
+  { pPitId :: Text
+  , keepAlive :: Text
+  } deriving (Eq, Show)
+
+instance ToJSON PointInTime where
+  toJSON PointInTime{..} =
+    object [ "id" .= pPitId
+           , "keep_alive" .= keepAlive ]
+
+instance FromJSON PointInTime where
+  parseJSON (Object o) = PointInTime <$> o .: "id" <*> o .: "keep_alive"
+  parseJSON x = typeMismatch "PointInTime" x
+
+data OpenPointInTimeResponse = OpenPointInTimeResponse {
+    oPitId :: Text
+} deriving (Eq, Show)
+
+instance ToJSON OpenPointInTimeResponse where
+    toJSON OpenPointInTimeResponse{..} =
+        object [ "id" .= oPitId]
+
+instance FromJSON OpenPointInTimeResponse where
+  parseJSON (Object o) = OpenPointInTimeResponse <$> o .: "id"
+  parseJSON x = typeMismatch "OpenPointInTimeResponse" x
+
+data ClosePointInTime = ClosePointInTime {
+    cPitId :: Text
+} deriving (Eq, Show)
+
+instance ToJSON ClosePointInTime where
+    toJSON ClosePointInTime{..} =
+        object [ "id" .= cPitId]
+
+instance FromJSON ClosePointInTime where
+  parseJSON (Object o) = ClosePointInTime <$> o .: "id"
+  parseJSON x = typeMismatch "ClosePointInTime" x
+
+data ClosePointInTimeResponse = ClosePointInTimeResponse {
+    succeeded :: Bool,
+    numFreed :: Int
+} deriving (Eq, Show)
+
+instance ToJSON ClosePointInTimeResponse where
+    toJSON ClosePointInTimeResponse{..} =
+        object [ "succeeded" .= succeeded
+               , "num_freed" .= numFreed]
+
+instance FromJSON ClosePointInTimeResponse where
+  parseJSON (Object o) = do
+    succeeded' <- o .: "succeeded"
+    numFreed' <- o .: "num_freed"
+    return $ ClosePointInTimeResponse succeeded' numFreed'
+  parseJSON x = typeMismatch "ClosePointInTimeResponse" x

--- a/tests/Test/Common.hs
+++ b/tests/Test/Common.hs
@@ -110,6 +110,16 @@ tweetWithExtra = Tweet { user     = "bitemyapp"
                        , location = Location 40.12 (-71.34)
                        , extra = Just "blah blah" }
 
+exampleTweetWithAge :: Int -> Tweet
+exampleTweetWithAge age = Tweet { user     = "bitemyapp"
+                                , postDate = UTCTime
+                                            (ModifiedJulianDay 55000)
+                                            (secondsToDiffTime 10)
+                                , message  = "Use haskell!"
+                                , age      = age
+                                , location = Location 40.12 (-71.34)
+                                , extra = Nothing }
+
 newAge :: Int
 newAge = 31337
 
@@ -150,6 +160,13 @@ insertData = do
 insertData' :: IndexDocumentSettings -> BH IO Reply
 insertData' ids = do
   r <- indexDocument testIndex ids exampleTweet (DocId "1")
+  _ <- refreshIndex testIndex
+  return r
+
+insertTweetWithDocId :: Tweet -> Text -> BH IO Reply
+insertTweetWithDocId tweet docId = do
+  let ids = defaultIndexDocumentSettings
+  r <- indexDocument testIndex ids tweet (DocId docId)
   _ <- refreshIndex testIndex
   return r
 

--- a/tests/Test/Sorting.hs
+++ b/tests/Test/Sorting.hs
@@ -15,7 +15,7 @@ spec =
       let search = Search Nothing
                    Nothing (Just [sortSpec]) Nothing Nothing
                    False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing
-                   Nothing Nothing
+                   Nothing Nothing Nothing
       result <- searchTweets search
       let myTweet = grabFirst result
       liftIO $


### PR DESCRIPTION
Adds support for https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html, which is now recommended over the scroll API for deep pagination.

I considered introducing a new exception type, or returning an error, instead of using `error` in `pitSearch` and `pitAccumulator`, but the cases they handle _should_ be impossible.

In the future it would be nice to introduce [advanceScroll](https://github.com/bitemyapp/bloodhound/blob/4775ebb759fe1b7cb5f880e4a41044b2363d98af/src/Database/Bloodhound/Client.hs#L1169) type functionality for the PIT API. This will require [passing some state around](https://github.com/mirokuratczyk/bloodhound/blob/36c682c63cb0268c3b9711403be7fbd608235666/src/Database/Bloodhound/Client.hs#L1241-L1243) between calls so I left it out for now, because this change should be sufficient for using the API.

We've been relying on this change in our fork so it would be great to get it merged so we can point to upstream again.