### PR TITLE
Update aeson min-bound to >=2.0

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -50,7 +50,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      aeson >=0.11.1
+      aeson >=2.0
     , base >=4.14 && <5
     , blaze-builder
     , bytestring >=0.10.0


### PR DESCRIPTION
This change prevents compilation error when building with aeson-1:

  src/Bloodhound/Import.hs:28:1: error:
      Could not find module ‘Data.Aeson.Key’