### PR TITLE
chore: Let shell.nix depend on nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,19 @@
 {
   "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +50,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
   };
 
   outputs = inputs@{ self, nixpkgs, flake-utils, ... }:

--- a/shell.nix
+++ b/shell.nix
@@ -1,17 +1,10 @@
-let
-  # cure = x: pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.doJailbreak x);
-  haskellOverlay = self: super: {
-    haskellPackages = super.haskell.packages.ghc922.override {
-      overrides = hself: hsuper: rec {
-        ghc-lib-parser = hsuper.ghc-lib-parser_9_2_2_20220307;
-      };
-    };
-  };
-in
-{ pkgs ? import <nixpkgs> { overlays = [ haskellOverlay ]; } }:
-
-pkgs.mkShell {
-  buildInputs = [
-    pkgs.haskellPackages.ormolu_0_5_0_0
-  ];
-}
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
It's usually better to have one source of truth (regarding package sources/versions) than two. So, use the compatibility mixin for those who want to keep using shell.nix.

GHC 9.2 is not supported anymore ("end of life".) Thus, we don't need overrides for it.