### PR TITLE
feature: Add docker-compose to flake / devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,13 +44,14 @@
               };
             in
             pkgs.mkShell {
-              buildInputs = [pkgs.docker-compose] ++ (with haskellPackages; [
+              buildInputs = with haskellPackages; [
+                pkgs.docker-compose
                 haskell-language-server
                 ghcid
                 cabal-install
                 scripts
                 ormolu
-              ]);
+              ];
               inputsFrom = [
                 (enableTests self.defaultPackage.${system}).env
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -44,13 +44,13 @@
               };
             in
             pkgs.mkShell {
-              buildInputs = with haskellPackages; [
+              buildInputs = [pkgs.docker-compose] ++ (with haskellPackages; [
                 haskell-language-server
                 ghcid
                 cabal-install
                 scripts
                 ormolu
-              ];
+              ]);
               inputsFrom = [
                 (enableTests self.defaultPackage.${system}).env
               ];


### PR DESCRIPTION
`dockerd` relies on superuser/system access and thus should be provided by the operating system. However, `docker-compose` simply uses `dockerd` and thus can be part of the flake's dependencies for the `devShell`.