### PR TITLE
chore: Replace stack by cabal in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build-docs.*
 .direnv
 .env
 result
+test-failure-report

--- a/Makefile
+++ b/Makefile
@@ -3,49 +3,38 @@
 
 .DEFAULT_GOAL = help
 
-stack = STACK_YAML='stack.yaml' stack
 ghc_perf_options = --ghc-options '+RTS -A128M -RTS'
 build = build $(ghc_perf_options)
-ghci = ghci $(ghc_perf_options)
+ghci = repl $(ghc_perf_options)
 test = test $(ghc_perf_options)
-stack-8.0 = STACK_YAML="stack-8.0.yaml" stack
-stack-8.2 = STACK_YAML="stack-8.2.yaml" stack
-stack-8.4 = STACK_YAML="stack-8.4.yaml" stack
-stack-8.6 = STACK_YAML="stack-8.6.yaml" stack
-
-# stack build --ghc-options '+RTS -A128M -RTS'
 
 ## run build
 build:
-	$(stack) $(build)
+	cabal $(build)
 
 ## build with validation options (Wall, Werror)
 build-validate:
-	$(stack) build --fast --ghc-options '-Wall -Werror +RTS -A128M -RTS'
+	cabal build --disable-optimization --ghc-options '-Wall -Werror +RTS -A128M -RTS'
 
 ## run ghci
 ghci:
-	$(stack) $(ghci)
+	cabal $(ghci)
 
 ## run tests
 test: echo-warn
-	$(stack) $(test)
+	cabal $(test)
 
 ## run tests with forced re-run via "-r"
 test-rerun: echo-warn
-	$(stack) $(test) --test-arguments "-r"
+	cabal $(test) --test-options='-r --failure-report test-failure-report'
 
 ## run ghci with test stanza
 test-ghci:
-	$(stack) $(ghci) bloodhound:test:bloodhound-tests
+	cabal $(ghci) bloodhound:test:bloodhound-tests
 
 ## run ghcid
 ghcid:
-	ghcid -c "$(stack) ghci bloodhound:lib --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is bloodhound:test:bloodhound-tests"
-
-## run ghcid with validate options (Werror, etc.)
-ghcid-validate:
-	ghcid -c "$(stack) ghci bloodhound:lib --test --ghci-options='-Werror -fobject-code -fno-warn-unused-do-bind' --main-is bloodhound:test:bloodhound-tests"
+	ghcid
 
 ## run weeder
 weeder:
@@ -64,34 +53,6 @@ hlint-watch:
 
 echo-warn:
 	@echo "Make certain you have an elasticsearch instance on localhost:9200 !"
-
-## Test with GHC 8.0 and ES 5.x
-test-8.0:
-	STACK_YAML="stack-8.0.yaml" stack test --fast bloodhound:test:bloodhound-tests --test-arguments="--qc-max-success 500"
-
-## Test with GHC 8.2 and ES 5.x
-test-8.2:
-	STACK_YAML="stack.yaml" stack test --fast bloodhound:test:bloodhound-tests --test-arguments="--qc-max-success 500"
-
-## Build with the GHC 8.0 Stack YAML
-build-8.0:
-	$(stack-8.0) $(build)
-
-## Build with the GHC 8.2 Stack YAML
-build-8.2:
-	$(stack-8.2) $(build)
-
-## Build with the GHC 8.4 Stack YAML
-build-8.4:
-	$(stack-8.4) $(build)
-
-## Build with the GHC 8.6 Stack YAML
-build-8.6:
-	$(stack-8.6) $(build)
-
-## Upload the package to Hackage
-upload:
-	stack upload --no-signature .
 
 # Create ES instance
 

--- a/README.md
+++ b/README.md
@@ -33,15 +33,16 @@ Bloodhound is stable for production use. I will strive to avoid breaking API com
 Testing
 -------
 
-The TravisCI tests are run using [Stack](http://docs.haskellstack.org/en/stable/README.html). You should use Stack instead of `cabal` to build and test Bloodhound to avoid compatibility problems. You will also need to have an Elasticsearch instance running at `localhost:9200` in order to execute some of the tests. See the "Version compatibility" section above for a list of Elasticsearch versions that are officially validated against in TravisCI.
+The Bloodhound project uses Github workflows using Cabal to test for regressions
+and compatibility. A convenient development environment is provided by Nix and a
+Makefile, though the project can be built with only Cabal.
 
-Steps to run the tests locally:
-  1. Dig through the [past releases] (https://www.elastic.co/downloads/past-releases) section of the Elasticsearch download page and install the desired Elasticsearch versions.
-  2. Install [Stack] (http://docs.haskellstack.org/en/stable/README.html#how-to-install)
-  3. In your local Bloodhound directory, run `stack setup && stack build`
-  4. Start the desired version of Elasticsearch at `localhost:9200`, which should be the default.
-  5. Run `stack test` in your local Bloodhound directory.
-  6. The unit tests will pass if you re-execute `stack test`. If you want to start with a clean slate, stop your Elasticsearch instance, delete the `data/` folder in the Elasticsearch installation, restart Elasticsearch, and re-run `stack test`.
+To run the tests:
+1. Get into the Nix environment by running `nix develop` (or `nix-shell` for a non-flake setup)
+1. Start Elasticsearch defined by `docker-compose.yml`: `make compose`
+1. Run the tests with Cabal: `cabal test`
+
+The second step can be left out if ElasticSearch (or OpenSearch) is started manually.
 
 Contributions
 -------------


### PR DESCRIPTION
Looks like the stack project configuration has been removed before. This PR adjusts the `Makefile` accordingly (please see commit messages) and updates the docs.