### PR TITLE
chore: Update actions/cache plugin (Github CI)

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -47,7 +47,7 @@ jobs:
           echo "code-hash=$code_hash" >> "$GITHUB_OUTPUT"
       - name: Setup cache
         id: cache-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cabal/store
           key: compat-build-${{ steps.code-hash.outputs.code-hash}}

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -184,7 +184,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -220,7 +220,7 @@ jobs:
           docker logs es
           docker rm -f es
       - name: save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: always()
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}


### PR DESCRIPTION
This resolves deprecation warnings for v3.