### PR TITLE
fix: Parsing EsError for OpenSearch 1.3

### DIFF
--- a/tests/Test/JSONSpec.hs
+++ b/tests/Test/JSONSpec.hs
@@ -81,6 +81,20 @@ spec = do
           flagStrs = T.splitOn "|" str
        in noDuplicates flagStrs
 
+  describe "FromJSON EsError" $ do
+    it "should parse ElasticSearch 7 responses (status & error)" $ do
+      let mbJson = decode "{\"status\": 209, \"error\": \"Error message\"}"
+      mbJson `shouldBe` Just (EsError (Just 209) "Error message")
+
+    it "should parse ElasticSearch 7 responses (error.reason)" $ do
+      let mbJson = decode "{\"error\": {\"reason\": \"Error message\"}}"
+      mbJson `shouldBe` Just (EsError Nothing "Error message")
+
+    it "should parse OpenSearch 1.3 responses" $ do
+      -- This is a real error response for a version conflict
+      let mbJson = decode "{\"took\":9,\"timed_out\":false,\"total\":3,\"updated\":1,\"deleted\":0,\"batches\":1,\"version_conflicts\":2,\"noops\":0,\"retries\":{\"bulk\":0,\"search\":0},\"throttled_millis\":0,\"requests_per_second\":-1.0,\"throttled_until_millis\":0,\"failures\":[{\"index\":\"directory_test\",\"type\":\"_doc\",\"id\":\"9fda4188-2afd-490d-8796-e023df61a4e9\",\"cause\":{\"type\":\"version_conflict_engine_exception\",\"reason\":\"[9fda4188-2afd-490d-8796-e023df61a4e9]: version conflict, required seqNo [11], primary term [1]. current document has seqNo [16] and primary term [1]\",\"index\":\"directory_test\",\"shard\":\"0\",\"index_uuid\":\"Y3RpVY_DQEW9ULn8oGulrg\"},\"status\":409},{\"index\":\"directory_test\",\"type\":\"_doc\",\"id\":\"d70b631d-966a-4951-a94c-35ddc210f28a\",\"cause\":{\"type\":\"version_conflict_engine_exception\",\"reason\":\"[d70b631d-966a-4951-a94c-35ddc210f28a]: version conflict, required seqNo [13], primary term [1]. current document has seqNo [15] and primary term [1]\",\"index\":\"directory_test\",\"shard\":\"0\",\"index_uuid\":\"Y3RpVY_DQEW9ULn8oGulrg\"},\"status\":409}]}"
+      mbJson `shouldBe` Just (EsError (Just 409) "[9fda4188-2afd-490d-8796-e023df61a4e9]: version conflict, required seqNo [11], primary term [1]. current document has seqNo [16] and primary term [1]")
+
   describe "Exact isomorphism JSON instances" $ do
     propJSON (Proxy :: Proxy IndexName)
     propJSON (Proxy :: Proxy DocId)


### PR DESCRIPTION
The error format changed.

The solution isn't ideal as it drops all but the first failure. However, it's better than having to deal with `EsProtocolException`s.

The this would fix https://github.com/bitemyapp/bloodhound/issues/295