### PR TITLE
Improve response predicates

### DIFF
--- a/src/Database/Bloodhound/Internal/Client/BHRequest.hs
+++ b/src/Database/Bloodhound/Internal/Client/BHRequest.hs
@@ -304,7 +304,7 @@ eitherDecodeResponse ::
 eitherDecodeResponse = eitherDecode . responseBody . getResponse
 
 -- | Was there an optimistic concurrency control conflict when
--- indexing a document?
+-- indexing a document? (Check '409' status code.)
 isVersionConflict :: BHResponse parsingContext a -> Bool
 isVersionConflict = statusCheck (== 409)
 

--- a/tests/Test/DocumentsSpec.hs
+++ b/tests/Test/DocumentsSpec.hs
@@ -38,6 +38,21 @@ spec =
           Right (res', _) -> liftIO $ isVersionConflict res' `shouldBe` True
           Left e -> liftIO $ errorStatus e `shouldBe` Just 409
 
+    it "can use predicates on the response" $
+      withTestEnv $ do
+        let ev = ExternalDocVersion minBound
+        let cfg = defaultIndexDocumentSettings {idsVersionControl = ExternalGT ev}
+        resetIndex
+        (res, _) <- insertData' cfg
+        liftIO $ isCreated res `shouldBe` True
+        liftIO $ isSuccess res `shouldBe` True
+        liftIO $ isVersionConflict res `shouldBe` False
+
+        res' <- insertData'' cfg
+        liftIO $ isCreated res' `shouldBe` False
+        liftIO $ isSuccess res' `shouldBe` False
+        liftIO $ isVersionConflict res' `shouldBe` True
+
     it "indexes two documents in a parent/child relationship and checks that the child exists" $
       withTestEnv $ do
         resetIndex

--- a/tests/TestsUtils/Common.hs
+++ b/tests/TestsUtils/Common.hs
@@ -205,6 +205,13 @@ insertData' ids = do
   _ <- performBHRequest $ refreshIndex testIndex
   return r
 
+-- | Returns the `BHResponse` of `indexDocument` without any parsing
+insertData'' :: IndexDocumentSettings -> BH IO (BHResponse StatusDependant IndexedDocument)
+insertData'' ids = do
+  r <- dispatch $ indexDocument testIndex ids exampleTweet (DocId "1")
+  _ <- performBHRequest $ refreshIndex testIndex
+  return r
+
 insertTweetWithDocId :: Tweet -> Text -> BH IO IndexedDocument
 insertTweetWithDocId tweet docId = do
   let ids = defaultIndexDocumentSettings


### PR DESCRIPTION
- Add test to check response predicates
- Describe which HTTP status code we're checking against in `isVersionConflict`.